### PR TITLE
Use tree-sitter for CST, add more features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +99,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +156,7 @@ name = "biscuit-language-server"
 version = "0.1.0"
 dependencies = [
  "biscuit-auth",
+ "chrono",
  "dashmap",
  "env_logger",
  "im-rc",
@@ -223,6 +239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +267,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +290,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -684,6 +725,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1000,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -1271,6 +1356,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -1796,10 +1887,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,34 +3,19 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,33 +28,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -78,19 +63,19 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -101,29 +86,14 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -132,25 +102,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "biscuit-auth"
-version = "3.2.0"
+name = "base64ct"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1e91dedc0523e4ff74633d4bdac7251e40e0759f3e85f5f7995ff3c095c281"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "biscuit-auth"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5884fc86b3e21f5649ef4326e17ef729b3096e6502deaf13db7b7fb05bb992b"
 dependencies = [
  "base64",
  "biscuit-parser",
  "biscuit-quote",
+ "ecdsa",
  "ed25519-dalek",
+ "elliptic-curve",
  "getrandom",
  "hex",
  "nom",
+ "p256",
+ "pkcs8 0.9.0",
  "prost",
  "prost-types",
  "rand",
- "rand_core 0.5.1",
+ "rand_core",
  "regex",
- "sha2",
- "thiserror",
+ "serde_json",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
  "time",
  "zeroize",
 ]
@@ -171,30 +152,32 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower-lsp",
+ "tree-sitter",
+ "tree-sitter-biscuit",
 ]
 
 [[package]]
 name = "biscuit-parser"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9fd6da963e73f7e6db729c3bd76784863ba405b15acbbb5cb08ebc2adbd3bf"
+checksum = "9d7cafdbc8c30e1f0fb87df7161bec77f6f00da652cc33f102b0f95bd1cbc0fa"
 dependencies = [
  "hex",
  "nom",
  "proc-macro2",
  "quote",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
 name = "biscuit-quote"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0071fe3634b644a8df1434e3e14841e480c4238059c66a94e479b7eff98c2bd3"
+checksum = "49d2332c742a07a846f1fb2760e58a0ee60f2bc30987046fcea816b40630335a"
 dependencies = [
  "biscuit-parser",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -208,9 +191,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -231,28 +214,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
@@ -264,16 +266,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.1"
+name = "crypto-bigint"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "byteorder",
- "digest",
- "rand_core 0.5.1",
+ "generic-array",
+ "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -290,13 +328,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.4.0"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
- "powerfmt",
+ "bitflags 1.3.2",
+ "defmt-macros",
 ]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -308,50 +394,100 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "digest"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "serdect",
+ "signature",
+ "spki 0.7.3",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8 0.10.2",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand_core",
  "serde",
- "sha2",
+ "sha2 0.10.9",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sec1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -359,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -371,19 +507,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -395,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -405,44 +573,44 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -452,36 +620,41 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "group"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "hashbrown"
@@ -496,6 +669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,12 +685,13 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -516,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -529,11 +712,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -544,42 +726,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -589,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -600,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -615,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core 0.6.4",
+ "rand_core",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -623,21 +801,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -650,61 +817,61 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lsp-types"
@@ -721,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -732,22 +899,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -763,30 +921,21 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -801,10 +950,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae76739229d0cc5e834e0e3b9e8c4078a86828ff47f5bc71138e4571ce528f83"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
+name = "p256"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -812,75 +973,98 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "pkcs8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -901,34 +1085,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "primeorder"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
+ "elliptic-curve",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -968,43 +1159,32 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
- "rand_hc",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom",
+ "rand_core",
 ]
 
 [[package]]
@@ -1012,14 +1192,8 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1028,23 +1202,23 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1054,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1065,9 +1239,19 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "ropey"
@@ -1080,16 +1264,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1098,35 +1279,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "sec1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1137,7 +1350,17 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -1146,27 +1369,49 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
+name = "sha2"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
 
 [[package]]
 name = "sized-chunks"
@@ -1180,31 +1425,50 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
+name = "spki"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "str_indices"
@@ -1231,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1248,7 +1512,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1257,7 +1521,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1268,35 +1541,45 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1304,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1314,19 +1597,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -1334,20 +1614,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1407,7 +1687,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1418,9 +1698,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1429,46 +1709,66 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tree-sitter"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-biscuit"
+version = "0.0.1"
+source = "git+https://github.com/eclipse-biscuit/tree-sitter-biscuit?rev=bafc5e9a0b251bd1568a707d3584251b059a214c#bafc5e9a0b251bd1568a707d3584251b059a214c"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1491,102 +1791,37 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -1594,82 +1829,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1678,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1689,11 +1910,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ nom = "7.1.3"
 oxc_index = "0.36.0"
 tree-sitter = "~0.20.3"
 tree-sitter-biscuit = { git = "https://github.com/eclipse-biscuit/tree-sitter-biscuit", rev = "bafc5e9a0b251bd1568a707d3584251b059a214c" }
+chrono = "0.4"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ serde = { version = "1.0", features = ["derive"] }
 dashmap = "5.1.0"
 log = "0.4.14"
 im-rc = "15.0.0"
-biscuit-auth = "3.2.0"
+biscuit-auth = "6.0.0"
 nom = "7.1.3"
 oxc_index = "0.36.0"
+tree-sitter = "~0.20.3"
+tree-sitter-biscuit = { git = "https://github.com/eclipse-biscuit/tree-sitter-biscuit", rev = "bafc5e9a0b251bd1568a707d3584251b059a214c" }
 
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,51 @@
 
 ## Introduction
 
-This repo provides a (minimal) language server for biscuit datalog.
+This repo provides a language server for biscuit datalog.
 
-It is based on [tower-lsp](https://github.com/ebkalderon/tower-lsp) and [tower-lsp-boilerplate](https://github.com/IWANABETHATGUY/tower-lsp-boilerplate).
+## Demo
+
+[![asciicast](https://asciinema.org/a/1260820.svg)](https://asciinema.org/a/1260820)
 
 ## Features
 
-Some of these features, like _code completion_, require support for fault-tolerant parsing, which is not done yet. Other features, like _go to definition_ or _inlay hints_ might be hard to map to datalog semantics.
-
-- [x] syntactic error diagnostic
-- [ ] code completion
-- [ ] find reference
-- [ ] rename
-- [ ] semantic token
-- [ ] go to definition
-- [ ] inlay hints
+- syntactic error diagnostic
+- code completion
+- find reference
+- rename
+- go to definition
+- code actions
+  - add `trusting` clause
+  - convert `check` blocks
+  - convert `policy` blocks
+  - replace literal with parameter
+  - replace parameter with current date
+  - extract rule body
+  - inline rule body
+  - sort rule body (predicates first, expressions second)
 
 ## Installation / usage
 
 This language server has not been released yet and is not part of the [biscuit-auth VSCode extension](https://marketplace.visualstudio.com/items?itemName=biscuit-auth.vscode-biscuit).
 
-It can be used fairly easily from nvim or helix.
+You can build the binary locally (with `cargo install --path .`) and configure your editor to use it:
+
+### Helix
+
+First, make sure the `biscuit` language is configured in helix: <https://github.com/eclipse-biscuit/tree-sitter-biscuit#helix>.
+
+Then, update the `languages.toml` config file to:
+
+- add `biscuit-language-server` to biscuit’s `language-servers`;
+- add a new entry in `[language-server]`
+
+```toml
+[[language]]
+name = "biscuit"
+…
+language-servers = ["biscuit-language-server"]
+
+[language-server]
+…
+biscuit-language-server = { command = "biscuit-language-server" }
+```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.97.0"
 profile = "default"
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <unstable> {} }: with pkgs;
+
+mkShell {
+  buildInputs = [
+      rustup
+  ];
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,522 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Clément Delafargue <clement@delafargue.name>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! AST helpers for tree-sitter-biscuit
+//!
+//! This module provides high-level helpers for navigating, querying, and manipulating
+//! the Biscuit AST using tree-sitter.
+
+use ropey::Rope;
+use std::collections::{HashMap, HashSet};
+
+// ============================================================================
+// Navigation Helpers
+// ============================================================================
+
+/// Find the enclosing rule, check, or policy node
+pub fn find_enclosing_statement<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "rule" | "check" | "policy" => return Some(current),
+            _ => {
+                current = current.parent()?;
+            }
+        }
+    }
+}
+
+/// Find the enclosing rule_body node for scope-aware operations
+pub fn find_enclosing_rule_body<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "rule_body" => return Some(current),
+            _ => {
+                current = current.parent()?;
+            }
+        }
+    }
+}
+
+/// Find the enclosing predicate node
+pub fn find_enclosing_predicate<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+    let mut current = *node;
+    loop {
+        if current.kind() == "predicate" {
+            return Some(current);
+        }
+        current = current.parent()?;
+    }
+}
+
+// ============================================================================
+// Extraction Helpers
+// ============================================================================
+
+/// Extract all variables from a node
+pub fn extract_variables(node: &tree_sitter::Node, rope: &Rope) -> HashSet<String> {
+    let mut variables = HashSet::new();
+    visit_variables(node, rope, &mut |var_text| {
+        variables.insert(var_text.to_string());
+    });
+    variables
+}
+
+/// Extract the text of a node
+pub fn extract_node_text(node: &tree_sitter::Node, rope: &Rope) -> String {
+    rope.byte_slice(node.start_byte()..node.end_byte()).to_string()
+}
+
+/// Extract predicate parameters as a list of strings
+pub fn extract_predicate_parameters(predicate_node: &tree_sitter::Node, rope: &Rope) -> Vec<String> {
+    let mut params = Vec::new();
+    let mut cursor = predicate_node.walk();
+    for child in predicate_node.children(&mut cursor) {
+        if child.kind() == "term" {
+            params.push(extract_node_text(&child, rope));
+        }
+    }
+    params
+}
+
+/// Extract predicate name
+pub fn extract_predicate_name(predicate_node: &tree_sitter::Node, rope: &Rope) -> Option<String> {
+    let name_node = predicate_node.child(0)?;
+    if name_node.kind() == "nname" {
+        Some(extract_node_text(&name_node, rope))
+    } else {
+        None
+    }
+}
+
+/// Count predicate arity
+pub fn count_predicate_arity(predicate_node: &tree_sitter::Node) -> usize {
+    let mut count = 0;
+    let mut cursor = predicate_node.walk();
+    for child in predicate_node.children(&mut cursor) {
+        if child.kind() == "term" {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Check if a rule/check/policy has an origin clause
+pub fn has_origin_clause(statement_node: &tree_sitter::Node) -> bool {
+    let mut cursor = statement_node.walk();
+    for child in statement_node.children(&mut cursor) {
+        if child.kind() == "rule_body" {
+            let mut body_cursor = child.walk();
+            for body_child in child.children(&mut body_cursor) {
+                if body_child.kind() == "origin_clause" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// ============================================================================
+// Query Helpers
+// ============================================================================
+
+/// Find a rule definition by name and arity
+pub fn find_rule_by_name_and_arity<'a>(
+    root: &tree_sitter::Node<'a>,
+    name: &str,
+    arity: usize,
+    rope: &Rope,
+) -> Option<tree_sitter::Node<'a>> {
+    let mut result_range: Option<(usize, usize)> = None;
+
+    visit_node(root, &mut |node| {
+        if result_range.is_some() {
+            return;
+        }
+        if node.kind() == "rule" {
+            if let Some(head) = node.child_by_field_name("head") {
+                if head.kind() == "predicate" {
+                    if let Some(rule_name) = extract_predicate_name(&head, rope) {
+                        let rule_arity = count_predicate_arity(&head);
+                        if rule_name == name && rule_arity == arity {
+                            result_range = Some((node.start_byte(), node.end_byte()));
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    if let Some((start, end)) = result_range {
+        root.descendant_for_byte_range(start, end)
+    } else {
+        None
+    }
+}
+
+/// Collect all rule names from the document
+pub fn collect_all_rule_names(root: &tree_sitter::Node, rope: &Rope) -> HashSet<String> {
+    let mut names = HashSet::new();
+
+    visit_node(root, &mut |node| {
+        if node.kind() == "rule" {
+            if let Some(head) = node.child_by_field_name("head") {
+                if head.kind() == "predicate" {
+                    if let Some(name) = extract_predicate_name(&head, rope) {
+                        names.insert(name);
+                    }
+                }
+            }
+        }
+    });
+
+    names
+}
+
+/// Generate a unique name not present in the given set
+pub fn generate_unique_name(existing_names: &HashSet<String>, base_name: &str) -> String {
+    let mut candidate = base_name.to_string();
+    let mut counter = 1;
+    while existing_names.contains(&candidate) {
+        candidate = format!("{}_{}", base_name, counter);
+        counter += 1;
+    }
+    candidate
+}
+
+// ============================================================================
+// Manipulation Helpers
+// ============================================================================
+
+/// Substitute variables in a node using a substitution map
+/// Returns the text with variables replaced
+pub fn substitute_variables(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    subst_map: &HashMap<String, String>,
+) -> String {
+    let mut result = String::new();
+    let mut last_pos = node.start_byte();
+
+    // Collect all variable replacements
+    let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+    visit_variables(node, rope, &mut |var_text| {
+        if let Some(replacement) = subst_map.get(var_text) {
+            // Find the actual node position
+            visit_node(node, &mut |n| {
+                if n.kind() == "variable" {
+                    let text = extract_node_text(n, rope);
+                    if text == var_text {
+                        replacements.push((n.start_byte(), n.end_byte(), replacement.clone()));
+                    }
+                }
+            });
+        }
+    });
+
+    // Sort by position and deduplicate
+    replacements.sort_by_key(|r| r.0);
+    replacements.dedup_by_key(|r| r.0);
+
+    // Build result with replacements
+    for (start, end, replacement) in replacements {
+        if start > last_pos {
+            result.push_str(&rope.byte_slice(last_pos..start).to_string());
+        }
+        result.push_str(&replacement);
+        last_pos = end;
+    }
+
+    if last_pos < node.end_byte() {
+        result.push_str(&rope.byte_slice(last_pos..node.end_byte()).to_string());
+    }
+
+    result
+}
+
+// ============================================================================
+// Node Type Helpers
+// ============================================================================
+
+/// Check if a node is a variable
+pub fn is_variable(node: &tree_sitter::Node) -> bool {
+    node.kind() == "variable"
+}
+
+/// Check if a node is a literal (string, number, boolean, date, bytes)
+pub fn is_literal(node: &tree_sitter::Node) -> bool {
+    matches!(node.kind(), "string" | "number" | "boolean" | "date" | "bytes")
+}
+
+// ============================================================================
+// Visitor Helpers
+// ============================================================================
+
+/// Visit all nodes in a tree recursively
+pub fn visit_node<F>(node: &tree_sitter::Node, visitor: &mut F)
+where
+    F: FnMut(&tree_sitter::Node),
+{
+    visitor(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_node(&child, visitor);
+    }
+}
+
+/// Visit all variables in a tree and call the callback with their text
+pub fn visit_variables<F>(node: &tree_sitter::Node, rope: &Rope, callback: &mut F)
+where
+    F: FnMut(&str),
+{
+    visit_node(node, &mut |n| {
+        if is_variable(n) {
+            let var_text = extract_node_text(n, rope);
+            callback(&var_text);
+        }
+    });
+}
+
+// ============================================================================
+// Rule Body Helpers
+// ============================================================================
+
+/// Represents an item in a rule body
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuleBodyItem {
+    pub text: String,
+    pub kind: RuleBodyItemKind,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleBodyItemKind {
+    Predicate,
+    Expression,
+}
+
+/// Extract all items from a rule body
+pub fn extract_rule_body_items(rule_body_node: &tree_sitter::Node, rope: &Rope) -> Vec<RuleBodyItem> {
+    let mut items = Vec::new();
+    let mut cursor = rule_body_node.walk();
+
+    for child in rule_body_node.children(&mut cursor) {
+        let kind = match child.kind() {
+            "predicate" => RuleBodyItemKind::Predicate,
+            "expression" => RuleBodyItemKind::Expression,
+            _ => continue,
+        };
+
+        items.push(RuleBodyItem {
+            text: extract_node_text(&child, rope),
+            kind,
+            start: child.start_byte(),
+            end: child.end_byte(),
+        });
+    }
+
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn parse_biscuit(code: &str) -> (tree_sitter::Tree, Rope) {
+        let mut parser = Parser::new();
+        parser.set_language(tree_sitter_biscuit::language()).unwrap();
+        let tree = parser.parse(code, None).unwrap();
+        let rope = Rope::from_str(code);
+        (tree, rope)
+    }
+
+    #[test]
+    fn test_find_enclosing_statement() {
+        let (tree, _rope) = parse_biscuit("check if user($u);");
+        let root = tree.root_node();
+
+        // Find a variable node by byte range
+        let mut var_range = None;
+        visit_node(&root, &mut |node| {
+            if node.kind() == "variable" && var_range.is_none() {
+                var_range = Some((node.start_byte(), node.end_byte()));
+            }
+        });
+
+        let (start, end) = var_range.unwrap();
+        let var_node = root.descendant_for_byte_range(start, end).unwrap();
+        let statement = find_enclosing_statement(&var_node).unwrap();
+        assert_eq!(statement.kind(), "check");
+    }
+
+    #[test]
+    fn test_extract_variables() {
+        let (tree, rope) = parse_biscuit("rule($x, $y) <- user($x), role($y);");
+        let root = tree.root_node();
+
+        let vars = extract_variables(&root, &rope);
+        assert_eq!(vars.len(), 2);
+        assert!(vars.contains("$x"));
+        assert!(vars.contains("$y"));
+    }
+
+    #[test]
+    fn test_extract_predicate_name() {
+        let (tree, rope) = parse_biscuit("user($x);");
+        let root = tree.root_node();
+
+        // Find predicate by byte range
+        let mut pred_range = None;
+        visit_node(&root, &mut |node| {
+            if node.kind() == "predicate" && pred_range.is_none() {
+                pred_range = Some((node.start_byte(), node.end_byte()));
+            }
+        });
+
+        let (start, end) = pred_range.unwrap();
+        let predicate = root.descendant_for_byte_range(start, end).unwrap();
+        let name = extract_predicate_name(&predicate, &rope).unwrap();
+        assert_eq!(name, "user");
+    }
+
+    #[test]
+    fn test_count_predicate_arity() {
+        let (tree, _rope) = parse_biscuit("user($x, $y, $z);");
+        let root = tree.root_node();
+
+        // Find predicate by byte range
+        let mut pred_range = None;
+        visit_node(&root, &mut |node| {
+            if node.kind() == "predicate" && pred_range.is_none() {
+                pred_range = Some((node.start_byte(), node.end_byte()));
+            }
+        });
+
+        let (start, end) = pred_range.unwrap();
+        let predicate = root.descendant_for_byte_range(start, end).unwrap();
+        assert_eq!(count_predicate_arity(&predicate), 3);
+    }
+
+    #[test]
+    fn test_has_origin_clause() {
+        let (tree1, _) = parse_biscuit("check if user($u) trusting authority;");
+        let root1 = tree1.root_node();
+
+        // Find check node by byte range
+        let mut check1_range = None;
+        visit_node(&root1, &mut |node| {
+            if node.kind() == "check" && check1_range.is_none() {
+                check1_range = Some((node.start_byte(), node.end_byte()));
+            }
+        });
+        let (start, end) = check1_range.unwrap();
+        let check1 = root1.descendant_for_byte_range(start, end).unwrap();
+        assert!(has_origin_clause(&check1));
+
+        let (tree2, _) = parse_biscuit("check if user($u);");
+        let root2 = tree2.root_node();
+
+        // Find check node by byte range
+        let mut check2_range = None;
+        visit_node(&root2, &mut |node| {
+            if node.kind() == "check" && check2_range.is_none() {
+                check2_range = Some((node.start_byte(), node.end_byte()));
+            }
+        });
+        let (start, end) = check2_range.unwrap();
+        let check2 = root2.descendant_for_byte_range(start, end).unwrap();
+        assert!(!has_origin_clause(&check2));
+    }
+
+    #[test]
+    fn test_find_rule_by_name_and_arity() {
+        let code = r#"
+user($x) <- identity($x);
+user($x, $role) <- identity($x), role($role);
+"#;
+        let (tree, rope) = parse_biscuit(code);
+        let root = tree.root_node();
+
+        // Find user/1
+        let rule1 = find_rule_by_name_and_arity(&root, "user", 1, &rope).unwrap();
+        assert_eq!(rule1.kind(), "rule");
+
+        // Find user/2
+        let rule2 = find_rule_by_name_and_arity(&root, "user", 2, &rope).unwrap();
+        assert_eq!(rule2.kind(), "rule");
+
+        // Should not find user/3
+        let rule3 = find_rule_by_name_and_arity(&root, "user", 3, &rope);
+        assert!(rule3.is_none());
+    }
+
+    #[test]
+    fn test_generate_unique_name() {
+        let mut names = HashSet::new();
+        names.insert("foo".to_string());
+        names.insert("foo_1".to_string());
+
+        let unique = generate_unique_name(&names, "foo");
+        assert_eq!(unique, "foo_2");
+    }
+
+    #[test]
+    fn test_substitute_variables() {
+        let (tree, rope) = parse_biscuit("user($x), role($x, $y);");
+        let root = tree.root_node();
+
+        let mut subst_map = HashMap::new();
+        subst_map.insert("$x".to_string(), "$admin".to_string());
+        subst_map.insert("$y".to_string(), "\"moderator\"".to_string());
+
+        let result = substitute_variables(&root, &rope, &subst_map);
+        assert!(result.contains("$admin"));
+        assert!(result.contains("\"moderator\""));
+    }
+
+    #[test]
+    fn test_extract_rule_body_items() {
+        let (tree, rope) = parse_biscuit("rule($x) <- user($x), $x == \"admin\";");
+        let root = tree.root_node();
+
+        // Find rule_body by byte range
+        let mut rule_body_range = None;
+        visit_node(&root, &mut |node| {
+            if node.kind() == "rule_body" && rule_body_range.is_none() {
+                rule_body_range = Some((node.start_byte(), node.end_byte()));
+            }
+        });
+
+        let (start, end) = rule_body_range.unwrap();
+        let rule_body = root.descendant_for_byte_range(start, end).unwrap();
+
+        let items = extract_rule_body_items(&rule_body, &rope);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].kind, RuleBodyItemKind::Predicate);
+        assert_eq!(items[1].kind, RuleBodyItemKind::Expression);
+    }
+
+    #[test]
+    fn test_is_literal() {
+        let (tree, _) = parse_biscuit("user(\"alice\", 42, true);");
+        let root = tree.root_node();
+
+        let mut literals = Vec::new();
+        visit_node(&root, &mut |node| {
+            if is_literal(node) {
+                literals.push(node.kind().to_string());
+            }
+        });
+
+        assert!(literals.contains(&"string".to_string()));
+        assert!(literals.contains(&"number".to_string()));
+        assert!(literals.contains(&"boolean".to_string()));
+    }
+}

--- a/src/code_actions.rs
+++ b/src/code_actions.rs
@@ -1,0 +1,376 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Clément Delafargue <clement@delafargue.name>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use ropey::Rope;
+use tower_lsp::lsp_types::*;
+
+use crate::offset_to_position;
+
+/// Create code action to add a trusting clause to a rule/check/policy
+pub fn create_add_trusting_clause_action(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+) -> Option<CodeActionOrCommand> {
+    // Find the enclosing rule/check/policy
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "rule" | "check" | "policy" => break,
+            _ => {
+                current = current.parent()?;
+            }
+        }
+    }
+
+    // Check if it already has a trusting clause by looking for origin_clause
+    // The origin_clause is a child of rule_body, not a direct child of rule/check/policy
+    let has_trusting = {
+        let mut has_it = false;
+        let mut cursor = current.walk();
+        for child in current.children(&mut cursor) {
+            if child.kind() == "rule_body" {
+                // Look inside rule_body for origin_clause
+                let mut body_cursor = child.walk();
+                for body_child in child.children(&mut body_cursor) {
+                    if body_child.kind() == "origin_clause" {
+                        has_it = true;
+                        break;
+                    }
+                }
+            }
+            if has_it {
+                break;
+            }
+        }
+        has_it
+    };
+
+    if has_trusting {
+        return None; // Already has trusting clause
+    }
+
+    // Find where to insert the trusting clause
+    // For rules: after the rule_body
+    // For checks/policies: after the last rule_body
+    let insert_position = {
+        let mut last_body_end = None;
+        let mut cursor = current.walk();
+        for child in current.children(&mut cursor) {
+            if child.kind() == "rule_body" {
+                last_body_end = Some(child.end_byte());
+            }
+        }
+        last_body_end?
+    };
+
+    let insert_pos = offset_to_position(insert_position, rope)?;
+
+    // Create two variants: trusting authority and trusting previous
+    let mut changes_authority = std::collections::HashMap::new();
+    changes_authority.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(insert_pos, insert_pos),
+            new_text: " trusting authority".to_string(),
+        }],
+    );
+
+    let mut changes_previous = std::collections::HashMap::new();
+    changes_previous.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(insert_pos, insert_pos),
+            new_text: " trusting previous".to_string(),
+        }],
+    );
+
+    // Return both as separate actions
+    // For now, return the authority one (we can make this a menu later)
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: "Add trusting clause (authority)".to_string(),
+        kind: Some(CodeActionKind::REFACTOR),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes_authority),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    }))
+}
+
+/// Create code actions to convert between check variants (check if/check all/reject if)
+/// Returns all possible conversions from the current variant
+pub fn create_convert_check_variant_actions(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+) -> Vec<CodeActionOrCommand> {
+    // Find the enclosing check
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "check" => break,
+            _ => {
+                match current.parent() {
+                    Some(parent) => current = parent,
+                    None => return Vec::new(),
+                }
+            }
+        }
+    }
+
+    // The text of the check should start with "check if", "check all", or "reject if"
+    let start_byte = current.start_byte();
+    let check_text = rope.byte_slice(start_byte..current.end_byte()).to_string();
+
+    let current_variant = if check_text.starts_with("check if") {
+        "check if"
+    } else if check_text.starts_with("check all") {
+        "check all"
+    } else if check_text.starts_with("reject if") {
+        "reject if"
+    } else {
+        return Vec::new();
+    };
+
+    // All possible variants
+    let all_variants = vec!["check if", "check all", "reject if"];
+
+    // Filter out the current variant
+    let target_variants: Vec<&str> = all_variants
+        .into_iter()
+        .filter(|&v| v != current_variant)
+        .collect();
+
+    let variant_len = current_variant.len();
+    let start_pos = match offset_to_position(start_byte, rope) {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+    let end_pos = match offset_to_position(start_byte + variant_len, rope) {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+
+    // Create a code action for each target variant
+    target_variants
+        .into_iter()
+        .map(|target_variant| {
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(
+                uri.clone(),
+                vec![TextEdit {
+                    range: Range::new(start_pos, end_pos),
+                    new_text: target_variant.to_string(),
+                }],
+            );
+
+            CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Convert to '{}'", target_variant),
+                kind: Some(CodeActionKind::REFACTOR),
+                diagnostics: None,
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                command: None,
+                is_preferred: None,
+                disabled: None,
+                data: None,
+            })
+        })
+        .collect()
+}
+
+/// Create code actions to convert between policy types (allow if/deny if)
+pub fn create_convert_policy_type_actions(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+) -> Vec<CodeActionOrCommand> {
+    // Find the enclosing policy
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "policy" => break,
+            _ => {
+                match current.parent() {
+                    Some(parent) => current = parent,
+                    None => return Vec::new(),
+                }
+            }
+        }
+    }
+
+    // The text of the policy should start with "allow if" or "deny if"
+    let start_byte = current.start_byte();
+    let policy_text = rope.byte_slice(start_byte..current.end_byte()).to_string();
+
+    let (current_type, target_type) = if policy_text.starts_with("allow if") {
+        ("allow if", "deny if")
+    } else if policy_text.starts_with("deny if") {
+        ("deny if", "allow if")
+    } else {
+        return Vec::new();
+    };
+
+    let type_len = current_type.len();
+    let start_pos = match offset_to_position(start_byte, rope) {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+    let end_pos = match offset_to_position(start_byte + type_len, rope) {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(start_pos, end_pos),
+            new_text: target_type.to_string(),
+        }],
+    );
+
+    vec![CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Convert to '{}'", target_type),
+        kind: Some(CodeActionKind::REFACTOR),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    })]
+}
+
+/// Create code actions to convert a parameter to literal values
+pub fn create_convert_parameter_to_literal_actions(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+) -> Vec<CodeActionOrCommand> {
+    // Check if cursor is on a parameter
+    let target_node = match node.kind() {
+        "param" => *node,
+        _ => {
+            // Try parent
+            match node.parent() {
+                Some(parent) if parent.kind() == "param" => parent,
+                _ => return Vec::new(),
+            }
+        }
+    };
+
+    let start = target_node.start_byte();
+    let end = target_node.end_byte();
+
+    let start_pos = match offset_to_position(start, rope) {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+    let end_pos = match offset_to_position(end, rope) {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+
+    // Get current date in RFC3339 format
+    let now = chrono::Utc::now();
+    let date_str = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(start_pos, end_pos),
+            new_text: date_str.clone(),
+        }],
+    );
+
+    vec![CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Convert to current date ({})", date_str),
+        kind: Some(CodeActionKind::REFACTOR),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    })]
+}
+
+/// Create code action to convert a literal value to a parameter placeholder
+pub fn create_convert_to_parameter_action(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+    _start_offset: usize,
+    _end_offset: usize,
+) -> Option<CodeActionOrCommand> {
+    // Check if cursor is on a literal value (string, number, boolean, date, bytes)
+    let target_node = match node.kind() {
+        "string" | "number" | "boolean" | "date" | "bytes" => *node,
+        _ => {
+            // Try parent
+            let parent = node.parent()?;
+            match parent.kind() {
+                "string" | "number" | "boolean" | "date" | "bytes" => parent,
+                _ => return None,
+            }
+        }
+    };
+
+    let start = target_node.start_byte();
+    let end = target_node.end_byte();
+    let value = rope.byte_slice(start..end).to_string();
+
+    // Generate a parameter name based on the value type
+    let param_name = match target_node.kind() {
+        "string" => "value",
+        "number" => "number",
+        "boolean" => "flag",
+        "date" => "timestamp",
+        "bytes" => "data",
+        _ => "param",
+    };
+
+    let start_pos = offset_to_position(start, rope)?;
+    let end_pos = offset_to_position(end, rope)?;
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(start_pos, end_pos),
+            new_text: format!("{{{}}}", param_name),
+        }],
+    );
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Convert '{}' to parameter", value),
+        kind: Some(CodeActionKind::REFACTOR),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    }))
+}

--- a/src/code_actions.rs
+++ b/src/code_actions.rs
@@ -7,8 +7,9 @@
 use ropey::Rope;
 use tower_lsp::lsp_types::*;
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
+use crate::ast::{self, RuleBodyItemKind};
 use crate::offset_to_position;
 
 /// Create code action to add a trusting clause to a rule/check/policy
@@ -18,40 +19,10 @@ pub fn create_add_trusting_clause_action(
     uri: &Url,
 ) -> Option<CodeActionOrCommand> {
     // Find the enclosing rule/check/policy
-    let mut current = *node;
-    loop {
-        match current.kind() {
-            "rule" | "check" | "policy" => break,
-            _ => {
-                current = current.parent()?;
-            }
-        }
-    }
+    let current = ast::find_enclosing_statement(node)?;
 
-    // Check if it already has a trusting clause by looking for origin_clause
-    // The origin_clause is a child of rule_body, not a direct child of rule/check/policy
-    let has_trusting = {
-        let mut has_it = false;
-        let mut cursor = current.walk();
-        for child in current.children(&mut cursor) {
-            if child.kind() == "rule_body" {
-                // Look inside rule_body for origin_clause
-                let mut body_cursor = child.walk();
-                for body_child in child.children(&mut body_cursor) {
-                    if body_child.kind() == "origin_clause" {
-                        has_it = true;
-                        break;
-                    }
-                }
-            }
-            if has_it {
-                break;
-            }
-        }
-        has_it
-    };
-
-    if has_trusting {
+    // Check if it already has a trusting clause
+    if ast::has_origin_clause(&current) {
         return None; // Already has trusting clause
     }
 
@@ -71,9 +42,9 @@ pub fn create_add_trusting_clause_action(
 
     let insert_pos = offset_to_position(insert_position, rope)?;
 
-    // Create two variants: trusting authority and trusting previous
-    let mut changes_authority = std::collections::HashMap::new();
-    changes_authority.insert(
+    // Create trusting authority clause
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
         uri.clone(),
         vec![TextEdit {
             range: Range::new(insert_pos, insert_pos),
@@ -81,23 +52,12 @@ pub fn create_add_trusting_clause_action(
         }],
     );
 
-    let mut changes_previous = std::collections::HashMap::new();
-    changes_previous.insert(
-        uri.clone(),
-        vec![TextEdit {
-            range: Range::new(insert_pos, insert_pos),
-            new_text: " trusting previous".to_string(),
-        }],
-    );
-
-    // Return both as separate actions
-    // For now, return the authority one (we can make this a menu later)
     Some(CodeActionOrCommand::CodeAction(CodeAction {
         title: "Add trusting clause (authority)".to_string(),
         kind: Some(CodeActionKind::REFACTOR),
         diagnostics: None,
         edit: Some(WorkspaceEdit {
-            changes: Some(changes_authority),
+            changes: Some(changes),
             ..Default::default()
         }),
         command: None,
@@ -115,28 +75,25 @@ pub fn create_convert_check_variant_actions(
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
     // Find the enclosing check
-    let mut current = *node;
-    loop {
-        match current.kind() {
-            "check" => break,
-            _ => {
-                match current.parent() {
-                    Some(parent) => current = parent,
-                    None => return Vec::new(),
-                }
-            }
-        }
-    }
+    let current = match ast::find_enclosing_statement(node) {
+        Some(node) if node.kind() == "check" => node,
+        _ => return Vec::new(),
+    };
 
-    // The text of the check should start with "check if", "check all", or "reject if"
+    // Extract the check variant by examining the check text
+    // The grammar defines: choice("check if", "check all", "reject if")
+    // We need to find which variant this is by looking at the beginning of the node
     let start_byte = current.start_byte();
-    let check_text = rope.byte_slice(start_byte..current.end_byte()).to_string();
 
-    let current_variant = if check_text.starts_with("check if") {
+    // Look at first ~12 bytes to determine variant (longest is "reject if" = 9 chars)
+    let sample_end = (start_byte + 12).min(current.end_byte());
+    let check_prefix = rope.byte_slice(start_byte..sample_end).to_string().trim().to_lowercase();
+
+    let current_variant = if check_prefix.starts_with("check if") {
         "check if"
-    } else if check_text.starts_with("check all") {
+    } else if check_prefix.starts_with("check all") {
         "check all"
-    } else if check_text.starts_with("reject if") {
+    } else if check_prefix.starts_with("reject if") {
         "reject if"
     } else {
         return Vec::new();
@@ -198,26 +155,22 @@ pub fn create_convert_policy_type_actions(
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
     // Find the enclosing policy
-    let mut current = *node;
-    loop {
-        match current.kind() {
-            "policy" => break,
-            _ => {
-                match current.parent() {
-                    Some(parent) => current = parent,
-                    None => return Vec::new(),
-                }
-            }
-        }
-    }
+    let current = match ast::find_enclosing_statement(node) {
+        Some(node) if node.kind() == "policy" => node,
+        _ => return Vec::new(),
+    };
 
-    // The text of the policy should start with "allow if" or "deny if"
+    // Extract the policy type by examining the policy text
+    // The grammar defines: choice("allow if", "deny if")
     let start_byte = current.start_byte();
-    let policy_text = rope.byte_slice(start_byte..current.end_byte()).to_string();
 
-    let (current_type, target_type) = if policy_text.starts_with("allow if") {
+    // Look at first ~10 bytes to determine type (longest is "allow if" = 8 chars)
+    let sample_end = (start_byte + 10).min(current.end_byte());
+    let policy_prefix = rope.byte_slice(start_byte..sample_end).to_string().trim().to_lowercase();
+
+    let (current_type, target_type) = if policy_prefix.starts_with("allow if") {
         ("allow if", "deny if")
-    } else if policy_text.starts_with("deny if") {
+    } else if policy_prefix.starts_with("deny if") {
         ("deny if", "allow if")
     } else {
         return Vec::new();
@@ -323,16 +276,16 @@ pub fn create_convert_to_parameter_action(
     _start_offset: usize,
     _end_offset: usize,
 ) -> Option<CodeActionOrCommand> {
-    // Check if cursor is on a literal value (string, number, boolean, date, bytes)
-    let target_node = match node.kind() {
-        "string" | "number" | "boolean" | "date" | "bytes" => *node,
-        _ => {
-            // Try parent
-            let parent = node.parent()?;
-            match parent.kind() {
-                "string" | "number" | "boolean" | "date" | "bytes" => parent,
-                _ => return None,
-            }
+    // Check if cursor is on a literal value
+    let target_node = if ast::is_literal(node) {
+        *node
+    } else {
+        // Try parent
+        let parent = node.parent()?;
+        if ast::is_literal(&parent) {
+            parent
+        } else {
+            return None;
         }
     };
 
@@ -362,8 +315,15 @@ pub fn create_convert_to_parameter_action(
         }],
     );
 
+    // Truncate value for display (max 30 chars)
+    let display_value = if value.len() > 30 {
+        format!("{}...", value.chars().take(27).collect::<String>())
+    } else {
+        value
+    };
+
     Some(CodeActionOrCommand::CodeAction(CodeAction {
-        title: format!("Convert '{}' to parameter", value),
+        title: format!("Convert '{}' to parameter", display_value),
         kind: Some(CodeActionKind::REFACTOR),
         diagnostics: None,
         edit: Some(WorkspaceEdit {
@@ -382,38 +342,29 @@ pub fn create_extract_rule_action(
     node: &tree_sitter::Node,
     rope: &Rope,
     uri: &Url,
+    root: tree_sitter::Node,
 ) -> Option<CodeActionOrCommand> {
     // Find the enclosing check or policy
-    let mut current = *node;
-    let parent_kind = loop {
-        match current.kind() {
-            "check" | "policy" => break current.kind(),
-            _ => {
-                current = current.parent()?;
-            }
-        }
-    };
+    let current = ast::find_enclosing_statement(node)?;
+    let parent_kind = current.kind();
 
-    // Find the rule_body
-    let mut rule_body = None;
-    let mut cursor = current.walk();
-    for child in current.children(&mut cursor) {
-        if child.kind() == "rule_body" {
-            rule_body = Some(child);
-            break;
-        }
+    if parent_kind != "check" && parent_kind != "policy" {
+        return None;
     }
 
-    let rule_body_node = rule_body?;
+    // Find the rule_body
+    let rule_body_node = ast::find_enclosing_rule_body(node)?;
     let body_start = rule_body_node.start_byte();
     let body_end = rule_body_node.end_byte();
     let body_text = rope.byte_slice(body_start..body_end).to_string();
 
     // Extract all variables from the rule body
-    let variables = extract_variables_from_node(&rule_body_node, rope);
+    let variables = ast::extract_variables(&rule_body_node, rope);
 
-    // Generate rule signature
-    let rule_name = "extracted_rule";
+    // Generate unique rule name
+    let existing_names = ast::collect_all_rule_names(&root, rope);
+    let rule_name = ast::generate_unique_name(&existing_names, "extracted_rule");
+
     let params = if variables.is_empty() {
         String::new()
     } else {
@@ -470,27 +421,6 @@ pub fn create_extract_rule_action(
     }))
 }
 
-/// Extract all variables from a tree-sitter node
-fn extract_variables_from_node(node: &tree_sitter::Node, rope: &Rope) -> HashSet<String> {
-    let mut variables = HashSet::new();
-    visit_node_for_variables(node, rope, &mut variables);
-    variables
-}
-
-/// Recursively visit nodes to collect variables
-fn visit_node_for_variables(node: &tree_sitter::Node, rope: &Rope, variables: &mut HashSet<String>) {
-    if node.kind() == "variable" {
-        let start = node.start_byte();
-        let end = node.end_byte();
-        let var_text = rope.byte_slice(start..end).to_string();
-        variables.insert(var_text);
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        visit_node_for_variables(&child, rope, variables);
-    }
-}
 
 /// Create code action to inline a rule call
 pub fn create_inline_rule_action(
@@ -500,49 +430,38 @@ pub fn create_inline_rule_action(
     root: tree_sitter::Node,
 ) -> Option<CodeActionOrCommand> {
     // Find if we're on a predicate
-    let mut current = *node;
-    let predicate_node = loop {
-        if current.kind() == "predicate" {
-            break current;
-        }
-        current = current.parent()?;
-    };
+    let predicate_node = ast::find_enclosing_predicate(node)?;
 
     // Get predicate name and arity
-    let name_node = predicate_node.child(0)?;
-    if name_node.kind() != "nname" {
-        return None;
-    }
-
-    let pred_name = rope
-        .byte_slice(name_node.start_byte()..name_node.end_byte())
-        .to_string();
-
-    // Count arguments
-    let arity = count_predicate_arguments(&predicate_node, rope);
+    let pred_name = ast::extract_predicate_name(&predicate_node, rope)?;
+    let arity = ast::count_predicate_arity(&predicate_node);
 
     // Find the rule definition with matching name and arity
-    let rule_def = find_rule_definition(&root, &pred_name, arity, rope)?;
+    let rule_def = ast::find_rule_by_name_and_arity(&root, &pred_name, arity, rope)?;
 
     // Get rule head parameters
     let rule_head = rule_def.child_by_field_name("head")?;
-    let rule_params = extract_predicate_parameters(&rule_head, rope);
+    let rule_params = ast::extract_predicate_parameters(&rule_head, rope);
 
     // Get call arguments
-    let call_args = extract_predicate_parameters(&predicate_node, rope);
+    let call_args = ast::extract_predicate_parameters(&predicate_node, rope);
+
+    // Check arity match
+    if rule_params.len() != call_args.len() {
+        return None; // Arity mismatch, can't inline safely
+    }
 
     // Get rule body
     let rule_body = rule_def.child_by_field_name("body")?;
-    let body_text = rope
-        .byte_slice(rule_body.start_byte()..rule_body.end_byte())
-        .to_string();
 
-    // Perform variable substitution
-    let mut inlined_body = body_text.clone();
+    // Build parameter substitution map
+    let mut subst_map = HashMap::new();
     for (param, arg) in rule_params.iter().zip(call_args.iter()) {
-        // Replace all occurrences of param with arg in the body
-        inlined_body = inlined_body.replace(param, arg);
+        subst_map.insert(param.clone(), arg.clone());
     }
+
+    // Perform AST-based variable substitution
+    let inlined_body = ast::substitute_variables(&rule_body, rope, &subst_map);
 
     // Replace the predicate with the inlined body
     let pred_start = predicate_node.start_byte();
@@ -574,82 +493,6 @@ pub fn create_inline_rule_action(
     }))
 }
 
-/// Count arguments in a predicate
-fn count_predicate_arguments(predicate_node: &tree_sitter::Node, _rope: &Rope) -> usize {
-    let mut count = 0;
-    let mut cursor = predicate_node.walk();
-    for child in predicate_node.children(&mut cursor) {
-        if child.kind() == "term" {
-            count += 1;
-        }
-    }
-    count
-}
-
-/// Find a rule definition by name and arity
-fn find_rule_definition<'a>(
-    root: &tree_sitter::Node<'a>,
-    name: &str,
-    arity: usize,
-    rope: &Rope,
-) -> Option<tree_sitter::Node<'a>> {
-    // Store the byte range instead of the node
-    let mut result_range: Option<(usize, usize)> = None;
-    visit_node_simple(root, &mut |node| {
-        if result_range.is_some() {
-            return; // Already found
-        }
-        if node.kind() == "rule" {
-            if let Some(head) = node.child_by_field_name("head") {
-                if head.kind() == "predicate" {
-                    if let Some(name_node) = head.child(0) {
-                        if name_node.kind() == "nname" {
-                            let rule_name = rope
-                                .byte_slice(name_node.start_byte()..name_node.end_byte())
-                                .to_string();
-                            let rule_arity = count_predicate_arguments(&head, rope);
-                            if rule_name == name && rule_arity == arity {
-                                result_range = Some((node.start_byte(), node.end_byte()));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    });
-
-    // Reconstruct the node from the byte range
-    if let Some((start, end)) = result_range {
-        root.descendant_for_byte_range(start, end)
-    } else {
-        None
-    }
-}
-
-/// Extract parameters from a predicate (as strings)
-fn extract_predicate_parameters(predicate_node: &tree_sitter::Node, rope: &Rope) -> Vec<String> {
-    let mut params = Vec::new();
-    let mut cursor = predicate_node.walk();
-    for child in predicate_node.children(&mut cursor) {
-        if child.kind() == "term" {
-            let param_text = rope.byte_slice(child.start_byte()..child.end_byte()).to_string();
-            params.push(param_text);
-        }
-    }
-    params
-}
-
-/// Visit all nodes recursively (simple version)
-fn visit_node_simple<F>(node: &tree_sitter::Node, visitor: &mut F)
-where
-    F: FnMut(&tree_sitter::Node),
-{
-    visitor(node);
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        visit_node_simple(&child, visitor);
-    }
-}
 
 /// Create code action to sort a rule body
 pub fn create_sort_rule_body_action(
@@ -658,37 +501,13 @@ pub fn create_sort_rule_body_action(
     uri: &Url,
 ) -> Option<CodeActionOrCommand> {
     // Find the enclosing rule, check, or policy
-    let mut current = *node;
-    loop {
-        match current.kind() {
-            "rule" | "check" | "policy" => break,
-            _ => {
-                current = current.parent()?;
-            }
-        }
-    }
+    let _statement = ast::find_enclosing_statement(node)?;
 
-    // Find the first rule_body
-    let mut rule_body_node = None;
-    let mut cursor = current.walk();
-    for child in current.children(&mut cursor) {
-        if child.kind() == "rule_body" {
-            rule_body_node = Some(child);
-            break;
-        }
-    }
-
-    let body_node = rule_body_node?;
+    // Find the rule_body
+    let body_node = ast::find_enclosing_rule_body(node)?;
 
     // Extract all predicates and expressions from the body
-    let mut items: Vec<(String, usize, usize)> = Vec::new(); // (text, start, end)
-    let mut body_cursor = body_node.walk();
-    for child in body_node.children(&mut body_cursor) {
-        if child.kind() == "predicate" || child.kind() == "expression" {
-            let text = rope.byte_slice(child.start_byte()..child.end_byte()).to_string();
-            items.push((text, child.start_byte(), child.end_byte()));
-        }
-    }
+    let items = ast::extract_rule_body_items(&body_node, rope);
 
     if items.len() <= 1 {
         return None; // Nothing to sort
@@ -697,32 +516,28 @@ pub fn create_sort_rule_body_action(
     // Sort items: predicates before expressions, then alphabetically
     let mut sorted_items = items.clone();
     sorted_items.sort_by(|a, b| {
-        // Determine if item is predicate or expression
-        let a_is_pred = !a.0.contains("==") && !a.0.contains("!=") && !a.0.contains('>') && !a.0.contains('<');
-        let b_is_pred = !b.0.contains("==") && !b.0.contains("!=") && !b.0.contains('>') && !b.0.contains('<');
-
-        match (a_is_pred, b_is_pred) {
-            (true, false) => std::cmp::Ordering::Less,    // predicates before expressions
-            (false, true) => std::cmp::Ordering::Greater, // expressions after predicates
-            _ => a.0.cmp(&b.0),                           // alphabetical within same type
+        match (a.kind, b.kind) {
+            (RuleBodyItemKind::Predicate, RuleBodyItemKind::Expression) => std::cmp::Ordering::Less,
+            (RuleBodyItemKind::Expression, RuleBodyItemKind::Predicate) => std::cmp::Ordering::Greater,
+            _ => a.text.cmp(&b.text),
         }
     });
 
     // Check if already sorted
-    if items.iter().map(|i| &i.0).eq(sorted_items.iter().map(|i| &i.0)) {
+    if items.iter().map(|i| &i.text).eq(sorted_items.iter().map(|i| &i.text)) {
         return None; // Already sorted
     }
 
-    // Build the sorted text
+    // Build the sorted text with proper separators
     let sorted_text = sorted_items
         .iter()
-        .map(|i| i.0.clone())
+        .map(|i| i.text.clone())
         .collect::<Vec<_>>()
         .join(", ");
 
     // Find the range of all items
-    let start = items.iter().map(|i| i.1).min()?;
-    let end = items.iter().map(|i| i.2).max()?;
+    let start = items.iter().map(|i| i.start).min()?;
+    let end = items.iter().map(|i| i.end).max()?;
 
     let start_pos = offset_to_position(start, rope)?;
     let end_pos = offset_to_position(end, rope)?;

--- a/src/code_actions.rs
+++ b/src/code_actions.rs
@@ -7,6 +7,8 @@
 use ropey::Rope;
 use tower_lsp::lsp_types::*;
 
+use std::collections::HashSet;
+
 use crate::offset_to_position;
 
 /// Create code action to add a trusting clause to a rule/check/policy
@@ -363,6 +365,380 @@ pub fn create_convert_to_parameter_action(
     Some(CodeActionOrCommand::CodeAction(CodeAction {
         title: format!("Convert '{}' to parameter", value),
         kind: Some(CodeActionKind::REFACTOR),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    }))
+}
+
+/// Create code action to extract a check/policy body into a new rule
+pub fn create_extract_rule_action(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+) -> Option<CodeActionOrCommand> {
+    // Find the enclosing check or policy
+    let mut current = *node;
+    let parent_kind = loop {
+        match current.kind() {
+            "check" | "policy" => break current.kind(),
+            _ => {
+                current = current.parent()?;
+            }
+        }
+    };
+
+    // Find the rule_body
+    let mut rule_body = None;
+    let mut cursor = current.walk();
+    for child in current.children(&mut cursor) {
+        if child.kind() == "rule_body" {
+            rule_body = Some(child);
+            break;
+        }
+    }
+
+    let rule_body_node = rule_body?;
+    let body_start = rule_body_node.start_byte();
+    let body_end = rule_body_node.end_byte();
+    let body_text = rope.byte_slice(body_start..body_end).to_string();
+
+    // Extract all variables from the rule body
+    let variables = extract_variables_from_node(&rule_body_node, rope);
+
+    // Generate rule signature
+    let rule_name = "extracted_rule";
+    let params = if variables.is_empty() {
+        String::new()
+    } else {
+        let mut vars: Vec<_> = variables.into_iter().collect();
+        vars.sort();
+        vars.join(", ")
+    };
+
+    // Create the new rule
+    let new_rule = format!("{}({}) <- {};\n", rule_name, params, body_text);
+
+    // Find where to insert (at the start of the line containing the check/policy)
+    let insert_line_start = {
+        let start_byte = current.start_byte();
+        let line = rope.try_byte_to_line(start_byte).ok()?;
+        rope.try_line_to_byte(line).ok()?
+    };
+    let insert_pos = offset_to_position(insert_line_start, rope)?;
+
+    // Replace the body with a call to the new rule
+    let body_start_pos = offset_to_position(body_start, rope)?;
+    let body_end_pos = offset_to_position(body_end, rope)?;
+    let replacement = format!("{}({})", rule_name, params);
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![
+            // Insert the new rule at the beginning of the line
+            TextEdit {
+                range: Range::new(insert_pos, insert_pos),
+                new_text: new_rule,
+            },
+            // Replace the body with a predicate call
+            TextEdit {
+                range: Range::new(body_start_pos, body_end_pos),
+                new_text: replacement,
+            },
+        ],
+    );
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Extract {} body to rule", parent_kind),
+        kind: Some(CodeActionKind::REFACTOR_EXTRACT),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    }))
+}
+
+/// Extract all variables from a tree-sitter node
+fn extract_variables_from_node(node: &tree_sitter::Node, rope: &Rope) -> HashSet<String> {
+    let mut variables = HashSet::new();
+    visit_node_for_variables(node, rope, &mut variables);
+    variables
+}
+
+/// Recursively visit nodes to collect variables
+fn visit_node_for_variables(node: &tree_sitter::Node, rope: &Rope, variables: &mut HashSet<String>) {
+    if node.kind() == "variable" {
+        let start = node.start_byte();
+        let end = node.end_byte();
+        let var_text = rope.byte_slice(start..end).to_string();
+        variables.insert(var_text);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_node_for_variables(&child, rope, variables);
+    }
+}
+
+/// Create code action to inline a rule call
+pub fn create_inline_rule_action(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+    root: tree_sitter::Node,
+) -> Option<CodeActionOrCommand> {
+    // Find if we're on a predicate
+    let mut current = *node;
+    let predicate_node = loop {
+        if current.kind() == "predicate" {
+            break current;
+        }
+        current = current.parent()?;
+    };
+
+    // Get predicate name and arity
+    let name_node = predicate_node.child(0)?;
+    if name_node.kind() != "nname" {
+        return None;
+    }
+
+    let pred_name = rope
+        .byte_slice(name_node.start_byte()..name_node.end_byte())
+        .to_string();
+
+    // Count arguments
+    let arity = count_predicate_arguments(&predicate_node, rope);
+
+    // Find the rule definition with matching name and arity
+    let rule_def = find_rule_definition(&root, &pred_name, arity, rope)?;
+
+    // Get rule head parameters
+    let rule_head = rule_def.child_by_field_name("head")?;
+    let rule_params = extract_predicate_parameters(&rule_head, rope);
+
+    // Get call arguments
+    let call_args = extract_predicate_parameters(&predicate_node, rope);
+
+    // Get rule body
+    let rule_body = rule_def.child_by_field_name("body")?;
+    let body_text = rope
+        .byte_slice(rule_body.start_byte()..rule_body.end_byte())
+        .to_string();
+
+    // Perform variable substitution
+    let mut inlined_body = body_text.clone();
+    for (param, arg) in rule_params.iter().zip(call_args.iter()) {
+        // Replace all occurrences of param with arg in the body
+        inlined_body = inlined_body.replace(param, arg);
+    }
+
+    // Replace the predicate with the inlined body
+    let pred_start = predicate_node.start_byte();
+    let pred_end = predicate_node.end_byte();
+    let pred_start_pos = offset_to_position(pred_start, rope)?;
+    let pred_end_pos = offset_to_position(pred_end, rope)?;
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(pred_start_pos, pred_end_pos),
+            new_text: inlined_body,
+        }],
+    );
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Inline rule '{}'", pred_name),
+        kind: Some(CodeActionKind::REFACTOR_INLINE),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    }))
+}
+
+/// Count arguments in a predicate
+fn count_predicate_arguments(predicate_node: &tree_sitter::Node, _rope: &Rope) -> usize {
+    let mut count = 0;
+    let mut cursor = predicate_node.walk();
+    for child in predicate_node.children(&mut cursor) {
+        if child.kind() == "term" {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Find a rule definition by name and arity
+fn find_rule_definition<'a>(
+    root: &tree_sitter::Node<'a>,
+    name: &str,
+    arity: usize,
+    rope: &Rope,
+) -> Option<tree_sitter::Node<'a>> {
+    // Store the byte range instead of the node
+    let mut result_range: Option<(usize, usize)> = None;
+    visit_node_simple(root, &mut |node| {
+        if result_range.is_some() {
+            return; // Already found
+        }
+        if node.kind() == "rule" {
+            if let Some(head) = node.child_by_field_name("head") {
+                if head.kind() == "predicate" {
+                    if let Some(name_node) = head.child(0) {
+                        if name_node.kind() == "nname" {
+                            let rule_name = rope
+                                .byte_slice(name_node.start_byte()..name_node.end_byte())
+                                .to_string();
+                            let rule_arity = count_predicate_arguments(&head, rope);
+                            if rule_name == name && rule_arity == arity {
+                                result_range = Some((node.start_byte(), node.end_byte()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Reconstruct the node from the byte range
+    if let Some((start, end)) = result_range {
+        root.descendant_for_byte_range(start, end)
+    } else {
+        None
+    }
+}
+
+/// Extract parameters from a predicate (as strings)
+fn extract_predicate_parameters(predicate_node: &tree_sitter::Node, rope: &Rope) -> Vec<String> {
+    let mut params = Vec::new();
+    let mut cursor = predicate_node.walk();
+    for child in predicate_node.children(&mut cursor) {
+        if child.kind() == "term" {
+            let param_text = rope.byte_slice(child.start_byte()..child.end_byte()).to_string();
+            params.push(param_text);
+        }
+    }
+    params
+}
+
+/// Visit all nodes recursively (simple version)
+fn visit_node_simple<F>(node: &tree_sitter::Node, visitor: &mut F)
+where
+    F: FnMut(&tree_sitter::Node),
+{
+    visitor(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_node_simple(&child, visitor);
+    }
+}
+
+/// Create code action to sort a rule body
+pub fn create_sort_rule_body_action(
+    node: &tree_sitter::Node,
+    rope: &Rope,
+    uri: &Url,
+) -> Option<CodeActionOrCommand> {
+    // Find the enclosing rule, check, or policy
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "rule" | "check" | "policy" => break,
+            _ => {
+                current = current.parent()?;
+            }
+        }
+    }
+
+    // Find the first rule_body
+    let mut rule_body_node = None;
+    let mut cursor = current.walk();
+    for child in current.children(&mut cursor) {
+        if child.kind() == "rule_body" {
+            rule_body_node = Some(child);
+            break;
+        }
+    }
+
+    let body_node = rule_body_node?;
+
+    // Extract all predicates and expressions from the body
+    let mut items: Vec<(String, usize, usize)> = Vec::new(); // (text, start, end)
+    let mut body_cursor = body_node.walk();
+    for child in body_node.children(&mut body_cursor) {
+        if child.kind() == "predicate" || child.kind() == "expression" {
+            let text = rope.byte_slice(child.start_byte()..child.end_byte()).to_string();
+            items.push((text, child.start_byte(), child.end_byte()));
+        }
+    }
+
+    if items.len() <= 1 {
+        return None; // Nothing to sort
+    }
+
+    // Sort items: predicates before expressions, then alphabetically
+    let mut sorted_items = items.clone();
+    sorted_items.sort_by(|a, b| {
+        // Determine if item is predicate or expression
+        let a_is_pred = !a.0.contains("==") && !a.0.contains("!=") && !a.0.contains('>') && !a.0.contains('<');
+        let b_is_pred = !b.0.contains("==") && !b.0.contains("!=") && !b.0.contains('>') && !b.0.contains('<');
+
+        match (a_is_pred, b_is_pred) {
+            (true, false) => std::cmp::Ordering::Less,    // predicates before expressions
+            (false, true) => std::cmp::Ordering::Greater, // expressions after predicates
+            _ => a.0.cmp(&b.0),                           // alphabetical within same type
+        }
+    });
+
+    // Check if already sorted
+    if items.iter().map(|i| &i.0).eq(sorted_items.iter().map(|i| &i.0)) {
+        return None; // Already sorted
+    }
+
+    // Build the sorted text
+    let sorted_text = sorted_items
+        .iter()
+        .map(|i| i.0.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // Find the range of all items
+    let start = items.iter().map(|i| i.1).min()?;
+    let end = items.iter().map(|i| i.2).max()?;
+
+    let start_pos = offset_to_position(start, rope)?;
+    let end_pos = offset_to_position(end, rope)?;
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(start_pos, end_pos),
+            new_text: sorted_text,
+        }],
+    );
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: "Sort rule body".to_string(),
+        kind: Some(CodeActionKind::REFACTOR_REWRITE),
         diagnostics: None,
         edit: Some(WorkspaceEdit {
             changes: Some(changes),

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ impl LanguageServer for Backend {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
                     TextDocumentSyncKind::INCREMENTAL,
                 )),
-                completion_provider: None,
+                completion_provider: Some(CompletionOptions {
+                    resolve_provider: Some(false),
+                    trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
+                    ..Default::default()
+                }),
                 execute_command_provider: None,
 
                 workspace: Some(WorkspaceServerCapabilities {
@@ -62,6 +66,53 @@ impl LanguageServer for Backend {
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = params.text_document_position.text_document.uri.to_string();
+        let position = params.text_document_position.position;
+
+        let doc_data = match self.document_map.get(&uri) {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let tree = match &doc_data.tree {
+            Some(tree) => tree,
+            None => return Ok(None),
+        };
+
+        // Convert position to byte offset
+        let byte_offset = position_to_offset(&position, &doc_data.rope).unwrap_or(0);
+
+        // Find the node at cursor and extract data before dropping tree reference
+        let (node_kind, in_method_context) = {
+            let node = find_node_at_cursor(tree.root_node(), byte_offset);
+            let node_kind = node.kind().to_string();
+            let in_method_context = is_in_method_context(node, byte_offset, &doc_data.rope);
+            (node_kind, in_method_context)
+        };
+
+        // Get completions from multiple sources
+        let mut items = Vec::new();
+
+        // 1. Symbol-based completions (fact and rule names)
+        let symbol_items = get_symbol_completions(tree, &doc_data.rope);
+        items.extend(symbol_items);
+
+        // 2. Method completions (if we're in a method call context)
+        if in_method_context {
+            items.extend(get_method_completions());
+        }
+
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!("Completion at byte {} in node kind: {:?}, found {} items", byte_offset, node_kind, items.len()),
+            )
+            .await;
+
+        Ok(Some(CompletionResponse::Array(items)))
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,21 @@ impl LanguageServer for Backend {
         // 5. Convert parameter to literal
         actions.extend(code_actions::create_convert_parameter_to_literal_actions(&node, rope, &params.text_document.uri));
 
+        // 6. Extract rule
+        if let Some(action) = code_actions::create_extract_rule_action(&node, rope, &params.text_document.uri) {
+            actions.push(action);
+        }
+
+        // 7. Inline rule
+        if let Some(action) = code_actions::create_inline_rule_action(&node, rope, &params.text_document.uri, tree.root_node()) {
+            actions.push(action);
+        }
+
+        // 8. Sort rule body
+        if let Some(action) = code_actions::create_sort_rule_body_action(&node, rope, &params.text_document.uri) {
+            actions.push(action);
+        }
+
         if actions.is_empty() {
             Ok(None)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ impl LanguageServer for Backend {
                     trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
                     ..Default::default()
                 }),
+                definition_provider: Some(OneOf::Left(true)),
                 execute_command_provider: None,
 
                 workspace: Some(WorkspaceServerCapabilities {
@@ -51,7 +52,6 @@ impl LanguageServer for Backend {
                     file_operations: None,
                 }),
                 semantic_tokens_provider: None,
-                definition_provider: None,
                 references_provider: None,
                 rename_provider: None,
                 ..ServerCapabilities::default()
@@ -66,6 +66,58 @@ impl LanguageServer for Backend {
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let uri = params.text_document_position_params.text_document.uri.to_string();
+        let position = params.text_document_position_params.position;
+
+        let doc_data = match self.document_map.get(&uri) {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let tree = match &doc_data.tree {
+            Some(tree) => tree,
+            None => return Ok(None),
+        };
+
+        let rope = &doc_data.rope;
+        let byte_offset = position_to_offset(&position, rope).unwrap_or(0);
+
+        // Find the node at cursor
+        let node = find_node_at_cursor(tree.root_node(), byte_offset);
+
+        // Try to find definition based on node type
+        let location = match node.kind() {
+            "variable" => find_variable_definition(tree.root_node(), &node, byte_offset, rope),
+            "nname" => {
+                // Get the parent to determine arity
+                if let Some(parent) = node.parent() {
+                    find_symbol_definition(tree.root_node(), &node, &parent, rope)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        if let Some((start, end)) = location {
+            if let (Some(start_pos), Some(end_pos)) = (
+                offset_to_position(start, rope),
+                offset_to_position(end, rope),
+            ) {
+                return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                    uri: params.text_document_position_params.text_document.uri,
+                    range: Range::new(start_pos, end_pos),
+                })));
+            }
+        }
+
+        Ok(None)
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
@@ -626,6 +678,96 @@ fn find_enclosing_context(root: tree_sitter::Node, byte_offset: usize) -> Option
             }
         }
     }
+}
+
+/// Find the definition of a variable (first occurrence in scope)
+fn find_variable_definition(
+    root: tree_sitter::Node,
+    variable_node: &tree_sitter::Node,
+    byte_offset: usize,
+    rope: &Rope,
+) -> Option<(usize, usize)> {
+    // Get the variable name
+    let var_name = rope.byte_slice(variable_node.start_byte()..variable_node.end_byte()).to_string();
+
+    // Find the enclosing context (rule/check/policy)
+    let context = find_enclosing_context(root, byte_offset)?;
+
+    // Find the first occurrence of this variable in the context
+    let mut first_occurrence: Option<(usize, usize)> = None;
+
+    visit_node(&context, &mut |node| {
+        if node.kind() == "variable" {
+            let node_name = rope.byte_slice(node.start_byte()..node.end_byte()).to_string();
+            if node_name == var_name {
+                if let Some((first_start, _)) = first_occurrence {
+                    // Keep the earliest occurrence
+                    if node.start_byte() < first_start {
+                        first_occurrence = Some((node.start_byte(), node.end_byte()));
+                    }
+                } else {
+                    first_occurrence = Some((node.start_byte(), node.end_byte()));
+                }
+            }
+        }
+    });
+
+    first_occurrence
+}
+
+/// Find the definition of a fact or rule by name and arity
+fn find_symbol_definition(
+    root: tree_sitter::Node,
+    name_node: &tree_sitter::Node,
+    parent_node: &tree_sitter::Node,
+    rope: &Rope,
+) -> Option<(usize, usize)> {
+    let name = rope.byte_slice(name_node.start_byte()..name_node.end_byte()).to_string();
+
+    // Determine the arity from the parent node
+    let target_arity = match parent_node.kind() {
+        "fact" => count_fact_arguments(parent_node),
+        "predicate" => count_predicate_arguments(parent_node),
+        _ => return None, // Not a fact or predicate
+    };
+
+    let mut definition: Option<(usize, usize)> = None;
+
+    visit_node(&root, &mut |node| {
+        match node.kind() {
+            "fact" => {
+                // Check if this fact has the matching name and arity
+                if let Some(fact_name_node) = node.child_by_field_name("name").or_else(|| node.child(0)) {
+                    if fact_name_node.kind() == "nname" {
+                        let fact_name = rope.byte_slice(fact_name_node.start_byte()..fact_name_node.end_byte()).to_string();
+                        let fact_arity = count_fact_arguments(node);
+                        if fact_name == name && fact_arity == target_arity {
+                            definition = Some((fact_name_node.start_byte(), fact_name_node.end_byte()));
+                        }
+                    }
+                }
+            }
+            "rule" => {
+                // Check if this rule has the matching name and arity
+                if let Some(head) = node.child_by_field_name("head") {
+                    if head.kind() == "predicate" {
+                        if let Some(rule_name_node) = head.child(0) {
+                            if rule_name_node.kind() == "nname" {
+                                let rule_name = rope.byte_slice(rule_name_node.start_byte()..rule_name_node.end_byte()).to_string();
+                                let rule_arity = count_predicate_arguments(&head);
+                                if rule_name == name && rule_arity == target_arity {
+                                    definition = Some((rule_name_node.start_byte(), rule_name_node.end_byte()));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    });
+
+    definition
 }
 
 /// Check if we're in a context where method completion makes sense

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,15 +96,18 @@ impl LanguageServer for Backend {
         // Get completions from multiple sources
         let mut items = Vec::new();
 
-        // 1. Symbol-based completions (fact and rule names)
+        // 1. Keyword completions
+        items.extend(get_keyword_completions());
+
+        // 2. Symbol-based completions (fact and rule names)
         let symbol_items = get_symbol_completions(tree, &doc_data.rope);
         items.extend(symbol_items);
 
-        // 2. Variable completions (scoped to current context)
+        // 3. Variable completions (scoped to current context)
         let variable_items = get_variable_completions(tree, &doc_data.rope, byte_offset);
         items.extend(variable_items);
 
-        // 3. Method completions (if we're in a method call context)
+        // 4. Method completions (if we're in a method call context)
         if in_method_context {
             items.extend(get_method_completions());
         }
@@ -648,6 +651,90 @@ fn is_in_method_context(node: tree_sitter::Node, byte_offset: usize, rope: &Rope
     }
 
     false
+}
+
+/// Get hardcoded keyword completions for biscuit language constructs
+fn get_keyword_completions() -> Vec<CompletionItem> {
+    vec![
+        CompletionItem {
+            label: "check if".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Check constraint".to_string()),
+            insert_text: Some("check if $0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "check all".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Check all constraints".to_string()),
+            insert_text: Some("check all $0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "reject if".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Reject if condition".to_string()),
+            insert_text: Some("reject if $0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "allow if".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Allow if condition (policy)".to_string()),
+            insert_text: Some("allow if $0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "deny if".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Deny if condition (policy)".to_string()),
+            insert_text: Some("deny if $0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "trusting".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Origin clause".to_string()),
+            insert_text: Some("trusting $0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "previous".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Trust previous block".to_string()),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "authority".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Trust authority block".to_string()),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "true".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Boolean true".to_string()),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "false".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Boolean false".to_string()),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "null".to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some("Null value".to_string()),
+            ..Default::default()
+        },
+    ]
 }
 
 /// Get hardcoded method completions for biscuit built-in methods

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ impl LanguageServer for Backend {
                 definition_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
                 document_highlight_provider: Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Left(true)),
                 execute_command_provider: None,
 
                 workspace: Some(WorkspaceServerCapabilities {
@@ -54,7 +55,6 @@ impl LanguageServer for Backend {
                     file_operations: None,
                 }),
                 semantic_tokens_provider: None,
-                rename_provider: None,
                 ..ServerCapabilities::default()
             },
         })
@@ -67,6 +67,88 @@ impl LanguageServer for Backend {
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        let uri = params.text_document_position.text_document.uri.to_string();
+        let position = params.text_document_position.position;
+        let new_name = params.new_name;
+
+        let doc_data = match self.document_map.get(&uri) {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let tree = match &doc_data.tree {
+            Some(tree) => tree,
+            None => return Ok(None),
+        };
+
+        let rope = &doc_data.rope;
+        let byte_offset = position_to_offset(&position, rope).unwrap_or(0);
+
+        // Find the node at cursor
+        let node = find_node_at_cursor(tree.root_node(), byte_offset);
+
+        // Find all references to rename
+        let (references, is_variable) = match node.kind() {
+            "variable" => (
+                find_variable_references(tree.root_node(), &node, byte_offset, rope),
+                true,
+            ),
+            "nname" => {
+                if let Some(parent) = node.parent() {
+                    (
+                        find_symbol_references(tree.root_node(), &node, &parent, rope),
+                        false,
+                    )
+                } else {
+                    return Ok(None);
+                }
+            }
+            _ => return Ok(None),
+        };
+
+        if references.is_empty() {
+            return Ok(None);
+        }
+
+        // For variables, ensure the new name has the $ prefix
+        let final_new_name = if is_variable {
+            if new_name.starts_with('$') {
+                new_name
+            } else {
+                format!("${}", new_name)
+            }
+        } else {
+            new_name
+        };
+
+        // Create text edits for all references
+        let text_edits: Vec<TextEdit> = references
+            .into_iter()
+            .filter_map(|(start, end)| {
+                let start_pos = offset_to_position(start, rope)?;
+                let end_pos = offset_to_position(end, rope)?;
+                Some(TextEdit {
+                    range: Range::new(start_pos, end_pos),
+                    new_text: final_new_name.clone(),
+                })
+            })
+            .collect();
+
+        if text_edits.is_empty() {
+            return Ok(None);
+        }
+
+        // Create workspace edit
+        let mut changes = std::collections::HashMap::new();
+        changes.insert(params.text_document_position.text_document.uri, text_edits);
+
+        Ok(Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }))
     }
 
     async fn document_highlight(

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,40 +260,53 @@ impl Backend {
 
         let text = doc_data.rope.to_string();
         let rope = &doc_data.rope;
+        let mut diagnostics = Vec::new();
 
-        let errors = match parse_source(&text) {
-            Ok(_) => vec![],
-            Err(e) => e,
-        };
+        // 1. Tree-sitter syntax errors (from ERROR nodes)
+        if let Some(ref tree) = doc_data.tree {
+            let ts_errors = get_tree_sitter_errors(tree, rope);
+            diagnostics.extend(ts_errors);
+        }
 
-        let diagnostics = errors
-            .into_iter()
-            .filter_map(|item| {
-                let message = item.message.unwrap_or_else(|| "parse error".to_string());
-                let range = {
-                    let input = item.input.trim();
-                    // the parser sometimes returns an error with an empty message and empty input
-                    if input.is_empty() {
-                        return None;
-                    }
-                    let start = text.offset(input);
-                    let end = start + input.len();
-                    Range::new(
-                        offset_to_position(start, rope).unwrap(),
-                        offset_to_position(end, rope).unwrap(),
-                    )
-                };
-                Some(Diagnostic::new(
-                    range,
-                    Some(DiagnosticSeverity::ERROR),
-                    None,
-                    None,
-                    message,
-                    None,
-                    None,
-                ))
-            })
-            .collect::<Vec<_>>();
+        // 2. Biscuit-auth semantic errors (only if no syntax errors)
+        // This avoids cascading errors from broken syntax
+        if diagnostics.is_empty() {
+            let errors = match parse_source(&text) {
+                Ok(_) => vec![],
+                Err(e) => e,
+            };
+
+            let semantic_diagnostics = errors
+                .into_iter()
+                .filter_map(|item| {
+                    let message = item.message.unwrap_or_else(|| "parse error".to_string());
+                    let range = {
+                        let input = item.input.trim();
+                        // the parser sometimes returns an error with an empty message and empty input
+                        if input.is_empty() {
+                            return None;
+                        }
+                        let start = text.offset(input);
+                        let end = start + input.len();
+                        Range::new(
+                            offset_to_position(start, rope).unwrap(),
+                            offset_to_position(end, rope).unwrap(),
+                        )
+                    };
+                    Some(Diagnostic::new(
+                        range,
+                        Some(DiagnosticSeverity::ERROR),
+                        None,
+                        None,
+                        message,
+                        None,
+                        None,
+                    ))
+                })
+                .collect::<Vec<_>>();
+
+            diagnostics.extend(semantic_diagnostics);
+        }
 
         self.client
             .publish_diagnostics(uri.clone(), diagnostics, Some(version))
@@ -369,6 +382,50 @@ fn find_node_at_cursor(root: tree_sitter::Node, byte_offset: usize) -> tree_sitt
     }
 
     node
+}
+
+/// Extract syntax errors from tree-sitter ERROR nodes
+fn get_tree_sitter_errors(tree: &Tree, rope: &Rope) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let root = tree.root_node();
+
+    // Walk the tree to find ERROR and MISSING nodes
+    visit_node(&root, &mut |node| {
+        if node.is_error() || node.is_missing() {
+            let start = node.start_byte();
+            let end = node.end_byte();
+
+            // Get a meaningful error message
+            let message = if node.is_missing() {
+                format!("Missing: {}", node.kind())
+            } else {
+                // For ERROR nodes, try to show what was expected vs what was found
+                let text_slice = if end > start && (end - start) < 50 {
+                    rope.byte_slice(start..end).to_string()
+                } else {
+                    "<unknown>".to_string()
+                };
+                format!("Syntax error near: {}", text_slice)
+            };
+
+            if let (Some(start_pos), Some(end_pos)) = (
+                offset_to_position(start, rope),
+                offset_to_position(end.max(start + 1), rope),
+            ) {
+                diagnostics.push(Diagnostic::new(
+                    Range::new(start_pos, end_pos),
+                    Some(DiagnosticSeverity::ERROR),
+                    None,
+                    None,
+                    message,
+                    None,
+                    None,
+                ));
+            }
+        }
+    });
+
+    diagnostics
 }
 
 /// Extract fact and rule names from the tree for completion

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,18 @@ use ropey::Rope;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tree_sitter::{Parser, Tree};
+
+#[derive(Debug)]
+struct DocumentData {
+    rope: Rope,
+    tree: Option<Tree>,
+}
 
 #[derive(Debug)]
 struct Backend {
     client: Client,
-    document_map: DashMap<String, Rope>,
+    document_map: DashMap<String, DocumentData>,
 }
 
 #[tower_lsp::async_trait]
@@ -27,7 +34,7 @@ impl LanguageServer for Backend {
             capabilities: ServerCapabilities {
                 inlay_hint_provider: None,
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::FULL,
+                    TextDocumentSyncKind::INCREMENTAL,
                 )),
                 completion_provider: None,
                 execute_command_provider: None,
@@ -69,13 +76,74 @@ impl LanguageServer for Backend {
         .await
     }
 
-    async fn did_change(&self, mut params: DidChangeTextDocumentParams) {
-        self.on_change(TextDocumentItem {
-            uri: params.text_document.uri,
-            text: std::mem::take(&mut params.content_changes[0].text),
-            version: params.text_document.version,
-        })
-        .await
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri.to_string();
+
+        // Get or create document data
+        let mut doc_data = self.document_map.entry(uri.clone()).or_insert_with(|| {
+            DocumentData {
+                rope: Rope::new(),
+                tree: None,
+            }
+        });
+
+        // Apply each change incrementally
+        for change in params.content_changes {
+            if let Some(range) = change.range {
+                // Incremental change
+                let rope = &doc_data.rope;
+
+                // Convert LSP positions to byte offsets
+                let start_byte = position_to_offset(&range.start, rope).unwrap_or(0);
+                let end_byte = position_to_offset(&range.end, rope).unwrap_or(start_byte);
+
+                // Calculate positions for tree-sitter InputEdit
+                let start_position = tree_sitter::Point::new(
+                    range.start.line as usize,
+                    range.start.character as usize,
+                );
+                let old_end_position = tree_sitter::Point::new(
+                    range.end.line as usize,
+                    range.end.character as usize,
+                );
+
+                // Apply edit to rope
+                doc_data.rope.remove(start_byte..end_byte);
+                doc_data.rope.insert(start_byte, &change.text);
+
+                // Calculate new end position after insertion
+                let new_text_len = change.text.len();
+                let new_end_byte = start_byte + new_text_len;
+                let new_end_position = offset_to_point(new_end_byte, &doc_data.rope);
+
+                // Apply edit to tree if it exists
+                if let Some(ref mut tree) = doc_data.tree {
+                    let edit = tree_sitter::InputEdit {
+                        start_byte,
+                        old_end_byte: end_byte,
+                        new_end_byte,
+                        start_position,
+                        old_end_position,
+                        new_end_position,
+                    };
+                    tree.edit(&edit);
+                }
+            } else {
+                // Full document sync (fallback)
+                doc_data.rope = Rope::from_str(&change.text);
+                doc_data.tree = None;
+            }
+        }
+
+        // Reparse with tree-sitter incrementally using chunked parsing
+        let mut parser = Parser::new();
+        parser.set_language(tree_sitter_biscuit::language()).expect("Error loading biscuit grammar");
+        doc_data.tree = parse_rope(&mut parser, &doc_data.rope, doc_data.tree.as_ref());
+
+        drop(doc_data);
+
+        // Run diagnostics
+        self.run_diagnostics(&params.text_document.uri, params.text_document.version).await;
     }
 
     async fn did_save(&self, _: DidSaveTextDocumentParams) {
@@ -116,9 +184,33 @@ struct TextDocumentItem {
 impl Backend {
     async fn on_change(&self, params: TextDocumentItem) {
         let rope = ropey::Rope::from_str(&params.text);
-        self.document_map
-            .insert(params.uri.to_string(), rope.clone());
-        let errors = match parse_source(&params.text) {
+
+        // Parse with tree-sitter
+        let mut parser = Parser::new();
+        parser.set_language(tree_sitter_biscuit::language()).expect("Error loading biscuit grammar");
+        let tree = parser.parse(&params.text, None);
+
+        self.document_map.insert(
+            params.uri.to_string(),
+            DocumentData {
+                rope: rope.clone(),
+                tree,
+            },
+        );
+
+        self.run_diagnostics(&params.uri, params.version).await;
+    }
+
+    async fn run_diagnostics(&self, uri: &Url, version: i32) {
+        let doc_data = match self.document_map.get(&uri.to_string()) {
+            Some(data) => data,
+            None => return,
+        };
+
+        let text = doc_data.rope.to_string();
+        let rope = &doc_data.rope;
+
+        let errors = match parse_source(&text) {
             Ok(_) => vec![],
             Err(e) => e,
         };
@@ -133,11 +225,11 @@ impl Backend {
                     if input.is_empty() {
                         return None;
                     }
-                    let start = &params.text.offset(input);
+                    let start = text.offset(input);
                     let end = start + input.len();
                     Range::new(
-                        offset_to_position(*start, &rope).unwrap(),
-                        offset_to_position(end, &rope).unwrap(),
+                        offset_to_position(start, rope).unwrap(),
+                        offset_to_position(end, rope).unwrap(),
                     )
                 };
                 Some(Diagnostic::new(
@@ -153,7 +245,7 @@ impl Backend {
             .collect::<Vec<_>>();
 
         self.client
-            .publish_diagnostics(params.uri.clone(), diagnostics, Some(params.version))
+            .publish_diagnostics(uri.clone(), diagnostics, Some(version))
             .await;
     }
 }
@@ -180,4 +272,253 @@ fn offset_to_position(offset: usize, rope: &Rope) -> Option<Position> {
     let first_char_of_line = rope.try_line_to_char(line).ok()?;
     let column = offset - first_char_of_line;
     Some(Position::new(line as u32, column as u32))
+}
+
+fn position_to_offset(position: &Position, rope: &Rope) -> Option<usize> {
+    let line = position.line as usize;
+    let character = position.character as usize;
+    let line_start = rope.try_line_to_char(line).ok()?;
+    Some(line_start + character)
+}
+
+fn offset_to_point(offset: usize, rope: &Rope) -> tree_sitter::Point {
+    let line = rope.try_char_to_line(offset).unwrap_or(0);
+    let line_start = rope.try_line_to_char(line).unwrap_or(0);
+    let column = offset.saturating_sub(line_start);
+    tree_sitter::Point::new(line, column)
+}
+
+/// Parse a Rope with tree-sitter using chunked callbacks to avoid allocating the full text
+fn parse_rope(parser: &mut Parser, rope: &Rope, old_tree: Option<&Tree>) -> Option<Tree> {
+    parser.parse_with(
+        &mut |byte_offset, _point| {
+            // Return a chunk of bytes starting from byte_offset
+            // tree-sitter will call this callback multiple times to get the text in chunks
+            if byte_offset >= rope.len_bytes() {
+                return "";
+            }
+            let slice = rope.byte_slice(byte_offset..);
+            // Get the first chunk from the rope slice
+            // This avoids allocating a full string - we return a reference to ropey's internal buffer
+            slice.chunks().next().unwrap_or("")
+        },
+        old_tree,
+    )
+}
+
+/// Find the most specific node at the cursor position
+/// Falls back to parent if cursor is in ERROR or MISSING node
+fn find_node_at_cursor(root: tree_sitter::Node, byte_offset: usize) -> tree_sitter::Node {
+    let mut node = root.descendant_for_byte_range(byte_offset, byte_offset)
+        .unwrap_or(root);
+
+    // If we're in an ERROR or MISSING node, try to use the parent for better context
+    while (node.is_error() || node.is_missing()) && node.parent().is_some() {
+        node = node.parent().unwrap();
+    }
+
+    node
+}
+
+/// Extract fact and rule names from the tree for completion
+fn get_symbol_completions(tree: &Tree, rope: &Rope) -> Vec<CompletionItem> {
+    let mut items = Vec::new();
+    let root = tree.root_node();
+
+    // Walk the tree to find all facts and rules
+    visit_node(&root, &mut |node| {
+        match node.kind() {
+            "fact" => {
+                // Facts have structure: nname "(" fact_term, ... ")"
+                if let Some(name_node) = node.child_by_field_name("name").or_else(|| node.child(0)) {
+                    if name_node.kind() == "nname" {
+                        let start = name_node.start_byte();
+                        let end = name_node.end_byte();
+                        let name = rope.byte_slice(start..end).to_string();
+                        items.push(CompletionItem {
+                            label: name.clone(),
+                            kind: Some(CompletionItemKind::FUNCTION),
+                            detail: Some(format!("Fact: {}", name)),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            "rule" => {
+                // Rules have structure: head "<-" body
+                if let Some(head) = node.child_by_field_name("head") {
+                    if head.kind() == "predicate" {
+                        // Predicates have structure: nname "(" term, ... ")"
+                        if let Some(name_node) = head.child(0) {
+                            if name_node.kind() == "nname" {
+                                let start = name_node.start_byte();
+                                let end = name_node.end_byte();
+                                let name = rope.byte_slice(start..end).to_string();
+                                items.push(CompletionItem {
+                                    label: name.clone(),
+                                    kind: Some(CompletionItemKind::FUNCTION),
+                                    detail: Some(format!("Rule: {}", name)),
+                                    ..Default::default()
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    });
+
+    items
+}
+
+/// Visit all nodes in the tree recursively
+fn visit_node<F>(node: &tree_sitter::Node, visitor: &mut F)
+where
+    F: FnMut(&tree_sitter::Node),
+{
+    visitor(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_node(&child, visitor);
+    }
+}
+
+/// Check if we're in a context where method completion makes sense
+fn is_in_method_context(node: tree_sitter::Node, byte_offset: usize, rope: &Rope) -> bool {
+    // Check if we're inside a methods node
+    let mut current = node;
+    loop {
+        if current.kind() == "methods" {
+            return true;
+        }
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => break,
+        }
+    }
+
+    // Check if the previous character is a dot
+    if byte_offset > 0 {
+        let prev_char = rope.byte_slice((byte_offset - 1)..byte_offset);
+        if prev_char == "." {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Get hardcoded method completions for biscuit built-in methods
+/// Source: biscuit-rust/biscuit-parser/src/parser.rs
+fn get_method_completions() -> Vec<CompletionItem> {
+    vec![
+        // Binary methods (take an argument) - cursor between parens
+        CompletionItem {
+            label: "contains".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Check if string/array/set contains element".to_string()),
+            insert_text: Some("contains($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "starts_with".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Check if string starts with prefix".to_string()),
+            insert_text: Some("starts_with($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "ends_with".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Check if string ends with suffix".to_string()),
+            insert_text: Some("ends_with($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "matches".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Check if string matches regex pattern".to_string()),
+            insert_text: Some("matches($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "intersection".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Get intersection of two sets".to_string()),
+            insert_text: Some("intersection($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "union".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Get union of two sets".to_string()),
+            insert_text: Some("union($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "all".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Check if all elements satisfy a condition (closure)".to_string()),
+            insert_text: Some("all($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "any".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Check if any element satisfies a condition (closure)".to_string()),
+            insert_text: Some("any($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "get".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Get element from array/map".to_string()),
+            insert_text: Some("get($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "try_or".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Try operation or return fallback value".to_string()),
+            insert_text: Some("try_or($0)".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        // Unary methods (no argument) - cursor after parens
+        CompletionItem {
+            label: "length".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Get length of string/array/set".to_string()),
+            insert_text: Some("length()$0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        CompletionItem {
+            label: "type".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Get type of value".to_string()),
+            insert_text: Some("type()$0".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+        // External function call - cursor after :: to type function name
+        CompletionItem {
+            label: "extern::".to_string(),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some("Call external function (FFI)".to_string()),
+            insert_text: Some("extern::$0()".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        },
+    ]
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,11 @@ impl LanguageServer for Backend {
         let symbol_items = get_symbol_completions(tree, &doc_data.rope);
         items.extend(symbol_items);
 
-        // 2. Method completions (if we're in a method call context)
+        // 2. Variable completions (scoped to current context)
+        let variable_items = get_variable_completions(tree, &doc_data.rope, byte_offset);
+        items.extend(variable_items);
+
+        // 3. Method completions (if we're in a method call context)
         if in_method_context {
             items.extend(get_method_completions());
         }
@@ -443,10 +447,19 @@ fn get_symbol_completions(tree: &Tree, rope: &Rope) -> Vec<CompletionItem> {
                         let start = name_node.start_byte();
                         let end = name_node.end_byte();
                         let name = rope.byte_slice(start..end).to_string();
+
+                        // Count the number of arguments
+                        let arity = count_fact_arguments(node);
+                        let snippet = create_predicate_snippet(&name, arity);
+
                         items.push(CompletionItem {
-                            label: name.clone(),
+                            label: format!("{}/{}", name, arity),
                             kind: Some(CompletionItemKind::FUNCTION),
                             detail: Some(format!("Fact: {}", name)),
+                            insert_text: Some(snippet),
+                            insert_text_format: Some(InsertTextFormat::SNIPPET),
+                            filter_text: Some(name.clone()),
+                            sort_text: Some(name.clone()),
                             ..Default::default()
                         });
                     }
@@ -462,10 +475,19 @@ fn get_symbol_completions(tree: &Tree, rope: &Rope) -> Vec<CompletionItem> {
                                 let start = name_node.start_byte();
                                 let end = name_node.end_byte();
                                 let name = rope.byte_slice(start..end).to_string();
+
+                                // Count the number of arguments
+                                let arity = count_predicate_arguments(&head);
+                                let snippet = create_predicate_snippet(&name, arity);
+
                                 items.push(CompletionItem {
-                                    label: name.clone(),
+                                    label: format!("{}/{}", name, arity),
                                     kind: Some(CompletionItemKind::FUNCTION),
                                     detail: Some(format!("Rule: {}", name)),
+                                    insert_text: Some(snippet),
+                                    insert_text_format: Some(InsertTextFormat::SNIPPET),
+                                    filter_text: Some(name.clone()),
+                                    sort_text: Some(name.clone()),
                                     ..Default::default()
                                 });
                             }
@@ -480,6 +502,42 @@ fn get_symbol_completions(tree: &Tree, rope: &Rope) -> Vec<CompletionItem> {
     items
 }
 
+/// Count arguments in a fact node
+fn count_fact_arguments(fact_node: &tree_sitter::Node) -> usize {
+    let mut count = 0;
+    let mut cursor = fact_node.walk();
+    for child in fact_node.children(&mut cursor) {
+        if child.kind() == "fact_term" {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Count arguments in a predicate node
+fn count_predicate_arguments(predicate_node: &tree_sitter::Node) -> usize {
+    let mut count = 0;
+    let mut cursor = predicate_node.walk();
+    for child in predicate_node.children(&mut cursor) {
+        if child.kind() == "term" {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Create a snippet for a predicate with placeholders for each argument
+fn create_predicate_snippet(name: &str, arity: usize) -> String {
+    if arity == 0 {
+        format!("{}()$0", name)
+    } else {
+        let placeholders: Vec<String> = (1..=arity)
+            .map(|i| format!("${}", i))
+            .collect();
+        format!("{}({})$0", name, placeholders.join(", "))
+    }
+}
+
 /// Visit all nodes in the tree recursively
 fn visit_node<F>(node: &tree_sitter::Node, visitor: &mut F)
 where
@@ -489,6 +547,81 @@ where
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         visit_node(&child, visitor);
+    }
+}
+
+/// Extract variables from the tree for completion, scoped to the current context
+/// Returns unique variable names found in scope at the given byte offset
+fn get_variable_completions(tree: &Tree, rope: &Rope, byte_offset: usize) -> Vec<CompletionItem> {
+    let mut variables = std::collections::HashSet::new();
+    let root = tree.root_node();
+
+    // Find the enclosing rule/check/policy for the cursor position
+    let context_node = find_enclosing_context(root, byte_offset);
+
+    if let Some(context) = context_node {
+        // Only collect variables from the current scope
+        visit_node(&context, &mut |node| {
+            if node.kind() == "variable" {
+                let start = node.start_byte();
+                let end = node.end_byte();
+                // Exclude the variable currently being typed (cursor is within its range)
+                // and only include variables that end before the cursor
+                if end < byte_offset {
+                    let var_text = rope.byte_slice(start..end).to_string();
+                    variables.insert(var_text);
+                }
+            }
+        });
+    } else {
+        // Fallback: collect all variables in the document
+        visit_node(&root, &mut |node| {
+            if node.kind() == "variable" {
+                let start = node.start_byte();
+                let end = node.end_byte();
+                // Exclude the variable currently being typed
+                if end < byte_offset {
+                    let var_text = rope.byte_slice(start..end).to_string();
+                    variables.insert(var_text);
+                }
+            }
+        });
+    }
+
+    // Convert to completion items
+    variables
+        .into_iter()
+        .map(|var| {
+            // Strip the $ prefix from insert_text to avoid duplication
+            let insert_text = if let Some(stripped) = var.strip_prefix('$') {
+                stripped.to_string()
+            } else {
+                var.clone()
+            };
+
+            CompletionItem {
+                label: var.clone(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                detail: Some("Variable".to_string()),
+                insert_text: Some(insert_text),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+/// Find the enclosing rule/check/policy node for scope-aware completion
+fn find_enclosing_context(root: tree_sitter::Node, byte_offset: usize) -> Option<tree_sitter::Node> {
+    let mut current = root.descendant_for_byte_range(byte_offset, byte_offset)?;
+
+    // Walk up the tree to find a rule, check, or policy node
+    loop {
+        match current.kind() {
+            "rule" | "check" | "policy" => return Some(current),
+            _ => {
+                current = current.parent()?;
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+mod ast;
 mod code_actions;
 
 use nom::Offset;
@@ -117,7 +118,7 @@ impl LanguageServer for Backend {
         actions.extend(code_actions::create_convert_parameter_to_literal_actions(&node, rope, &params.text_document.uri));
 
         // 6. Extract rule
-        if let Some(action) = code_actions::create_extract_rule_action(&node, rope, &params.text_document.uri) {
+        if let Some(action) = code_actions::create_extract_rule_action(&node, rope, &params.text_document.uri, tree.root_node()) {
             actions.push(action);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+mod code_actions;
+
 use nom::Offset;
 
 use biscuit_auth::parser::parse_source;
@@ -45,6 +47,7 @@ impl LanguageServer for Backend {
                 references_provider: Some(OneOf::Left(true)),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 rename_provider: Some(OneOf::Left(true)),
+                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 execute_command_provider: None,
 
                 workspace: Some(WorkspaceServerCapabilities {
@@ -67,6 +70,57 @@ impl LanguageServer for Backend {
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        let uri = params.text_document.uri.to_string();
+        let range = params.range;
+
+        let doc_data = match self.document_map.get(&uri) {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let tree = match &doc_data.tree {
+            Some(tree) => tree,
+            None => return Ok(None),
+        };
+
+        let rope = &doc_data.rope;
+
+        // Convert range to byte offsets
+        let start_offset = position_to_offset(&range.start, rope).unwrap_or(0);
+        let end_offset = position_to_offset(&range.end, rope).unwrap_or(start_offset);
+
+        // Find node at cursor
+        let node = find_node_at_cursor(tree.root_node(), start_offset);
+
+        let mut actions = Vec::new();
+
+        // 1. Add trusting clause
+        if let Some(action) = code_actions::create_add_trusting_clause_action(&node, rope, &params.text_document.uri) {
+            actions.push(action);
+        }
+
+        // 2. Convert between check variants (returns all possible conversions)
+        actions.extend(code_actions::create_convert_check_variant_actions(&node, rope, &params.text_document.uri));
+
+        // 3. Convert between policy types
+        actions.extend(code_actions::create_convert_policy_type_actions(&node, rope, &params.text_document.uri));
+
+        // 4. Convert literal to parameter
+        if let Some(action) = code_actions::create_convert_to_parameter_action(&node, rope, &params.text_document.uri, start_offset, end_offset) {
+            actions.push(action);
+        }
+
+        // 5. Convert parameter to literal
+        actions.extend(code_actions::create_convert_parameter_to_literal_actions(&node, rope, &params.text_document.uri));
+
+        if actions.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(actions))
+        }
     }
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
@@ -588,7 +642,7 @@ async fn main() {
     Server::new(stdin, stdout, socket).serve(service).await;
 }
 
-fn offset_to_position(offset: usize, rope: &Rope) -> Option<Position> {
+pub fn offset_to_position(offset: usize, rope: &Rope) -> Option<Position> {
     let line = rope.try_char_to_line(offset).ok()?;
     let first_char_of_line = rope.try_line_to_char(line).ok()?;
     let column = offset - first_char_of_line;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ impl LanguageServer for Backend {
                     ..Default::default()
                 }),
                 definition_provider: Some(OneOf::Left(true)),
+                references_provider: Some(OneOf::Left(true)),
+                document_highlight_provider: Some(OneOf::Left(true)),
                 execute_command_provider: None,
 
                 workspace: Some(WorkspaceServerCapabilities {
@@ -52,7 +54,6 @@ impl LanguageServer for Backend {
                     file_operations: None,
                 }),
                 semantic_tokens_provider: None,
-                references_provider: None,
                 rename_provider: None,
                 ..ServerCapabilities::default()
             },
@@ -66,6 +67,121 @@ impl LanguageServer for Backend {
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn document_highlight(
+        &self,
+        params: DocumentHighlightParams,
+    ) -> Result<Option<Vec<DocumentHighlight>>> {
+        let uri = params.text_document_position_params.text_document.uri.to_string();
+        let position = params.text_document_position_params.position;
+
+        let doc_data = match self.document_map.get(&uri) {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let tree = match &doc_data.tree {
+            Some(tree) => tree,
+            None => return Ok(None),
+        };
+
+        let rope = &doc_data.rope;
+        let byte_offset = position_to_offset(&position, rope).unwrap_or(0);
+
+        // Find the node at cursor
+        let node = find_node_at_cursor(tree.root_node(), byte_offset);
+
+        // Find all references based on node type (same as find references)
+        let references = match node.kind() {
+            "variable" => find_variable_references(tree.root_node(), &node, byte_offset, rope),
+            "nname" => {
+                if let Some(parent) = node.parent() {
+                    find_symbol_references(tree.root_node(), &node, &parent, rope)
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        };
+
+        if references.is_empty() {
+            return Ok(None);
+        }
+
+        // Convert byte ranges to DocumentHighlight, excluding the one under cursor
+        let cursor_start = node.start_byte();
+        let cursor_end = node.end_byte();
+        let highlights: Vec<DocumentHighlight> = references
+            .into_iter()
+            .filter(|(start, end)| *start != cursor_start || *end != cursor_end)
+            .filter_map(|(start, end)| {
+                let start_pos = offset_to_position(start, rope)?;
+                let end_pos = offset_to_position(end, rope)?;
+                Some(DocumentHighlight {
+                    range: Range::new(start_pos, end_pos),
+                    kind: Some(DocumentHighlightKind::TEXT),
+                })
+            })
+            .collect();
+
+        Ok(Some(highlights))
+    }
+
+    async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
+        let uri = params.text_document_position.text_document.uri.to_string();
+        let position = params.text_document_position.position;
+
+        let doc_data = match self.document_map.get(&uri) {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let tree = match &doc_data.tree {
+            Some(tree) => tree,
+            None => return Ok(None),
+        };
+
+        let rope = &doc_data.rope;
+        let byte_offset = position_to_offset(&position, rope).unwrap_or(0);
+
+        // Find the node at cursor
+        let node = find_node_at_cursor(tree.root_node(), byte_offset);
+
+        // Find all references based on node type
+        let references = match node.kind() {
+            "variable" => find_variable_references(tree.root_node(), &node, byte_offset, rope),
+            "nname" => {
+                if let Some(parent) = node.parent() {
+                    find_symbol_references(tree.root_node(), &node, &parent, rope)
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        };
+
+        if references.is_empty() {
+            return Ok(None);
+        }
+
+        // Convert byte ranges to Locations, excluding the one under cursor
+        let cursor_start = node.start_byte();
+        let cursor_end = node.end_byte();
+        let locations: Vec<Location> = references
+            .into_iter()
+            .filter(|(start, end)| *start != cursor_start || *end != cursor_end)
+            .filter_map(|(start, end)| {
+                let start_pos = offset_to_position(start, rope)?;
+                let end_pos = offset_to_position(end, rope)?;
+                Some(Location {
+                    uri: params.text_document_position.text_document.uri.clone(),
+                    range: Range::new(start_pos, end_pos),
+                })
+            })
+            .collect();
+
+        Ok(Some(locations))
     }
 
     async fn goto_definition(
@@ -713,6 +829,87 @@ fn find_variable_definition(
     });
 
     first_occurrence
+}
+
+/// Find all references to a variable (within its scope)
+fn find_variable_references(
+    root: tree_sitter::Node,
+    variable_node: &tree_sitter::Node,
+    byte_offset: usize,
+    rope: &Rope,
+) -> Vec<(usize, usize)> {
+    let var_name = rope.byte_slice(variable_node.start_byte()..variable_node.end_byte()).to_string();
+
+    // Find the enclosing context (rule/check/policy)
+    let context = match find_enclosing_context(root, byte_offset) {
+        Some(ctx) => ctx,
+        None => return Vec::new(),
+    };
+
+    let mut references = Vec::new();
+
+    // Find all occurrences of this variable in the context
+    visit_node(&context, &mut |node| {
+        if node.kind() == "variable" {
+            let node_name = rope.byte_slice(node.start_byte()..node.end_byte()).to_string();
+            if node_name == var_name {
+                references.push((node.start_byte(), node.end_byte()));
+            }
+        }
+    });
+
+    references
+}
+
+/// Find all references to a fact or rule by name and arity
+fn find_symbol_references(
+    root: tree_sitter::Node,
+    name_node: &tree_sitter::Node,
+    parent_node: &tree_sitter::Node,
+    rope: &Rope,
+) -> Vec<(usize, usize)> {
+    let name = rope.byte_slice(name_node.start_byte()..name_node.end_byte()).to_string();
+
+    // Determine the arity from the parent node
+    let target_arity = match parent_node.kind() {
+        "fact" => count_fact_arguments(parent_node),
+        "predicate" => count_predicate_arguments(parent_node),
+        _ => return Vec::new(),
+    };
+
+    let mut references = Vec::new();
+
+    visit_node(&root, &mut |node| {
+        match node.kind() {
+            "fact" => {
+                // Check if this fact has the matching name and arity
+                if let Some(fact_name_node) = node.child_by_field_name("name").or_else(|| node.child(0)) {
+                    if fact_name_node.kind() == "nname" {
+                        let fact_name = rope.byte_slice(fact_name_node.start_byte()..fact_name_node.end_byte()).to_string();
+                        let fact_arity = count_fact_arguments(node);
+                        if fact_name == name && fact_arity == target_arity {
+                            references.push((fact_name_node.start_byte(), fact_name_node.end_byte()));
+                        }
+                    }
+                }
+            }
+            "predicate" => {
+                // Check if this predicate has the matching name and arity
+                if let Some(pred_name_node) = node.child(0) {
+                    if pred_name_node.kind() == "nname" {
+                        let pred_name = rope.byte_slice(pred_name_node.start_byte()..pred_name_node.end_byte()).to_string();
+                        let pred_arity = count_predicate_arguments(node);
+                        if pred_name == name && pred_arity == target_arity {
+                            references.push((pred_name_node.start_byte(), pred_name_node.end_byte()));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    });
+
+    references
 }
 
 /// Find the definition of a fact or rule by name and arity


### PR DESCRIPTION
The core idea of the PR is to leverage biscuit’s tree-sitter grammar, since it’s suited for a language server (it’s made for incremental parsing and is fault tolerant).

- the first commit updates dependencies
- the second one introduces tree-sitter and switches to incremental document store updates
- the third one adds support for autocompleting method names
- the fourth one surfaces TS parsing errors in addition to what biscuit-rust returns
- the fifth and sixth commits add autocompletion for more tokens
- the seventh adds support for `goto definiton` (variables and predicates)
- the eighth adds support for references (`goto reference` and `highlight reference`)
- the ninth adds support for renaming variables and predicates

Predicates are identified both by their name _and_ arity.

Note: claude code has been used to deliver those features

## TODO

use a proper tree-sitter-biscuit release